### PR TITLE
Improve tests around rubocop.yml config files

### DIFF
--- a/spec/cc/engine/rubocop_spec.rb
+++ b/spec/cc/engine/rubocop_spec.rb
@@ -39,7 +39,7 @@ module CC::Engine
         output = run_engine(config)
 
         assert includes_check?(output, "Style/AndOr")
-        assert !includes_check?(output, "Style/UselessAssignment")
+        assert !includes_check?(output, "Lint/UselessAssignment")
       end
 
       it "reads a file with a #!.*ruby declaration at the top" do

--- a/spec/cc/engine/rubocop_spec.rb
+++ b/spec/cc/engine/rubocop_spec.rb
@@ -42,6 +42,26 @@ module CC::Engine
         assert !includes_check?(output, "Lint/UselessAssignment")
       end
 
+      it "respects the default .rubocop.yml file" do
+        create_source_file("foo.rb", <<-EORUBY)
+          def method
+            unused = "x" and "y"
+
+            return false
+          end
+        EORUBY
+
+        create_source_file(
+          ".rubocop.yml",
+          "Lint/UselessAssignment:\n  Enabled: false\n"
+        )
+
+        output = run_engine
+
+        assert includes_check?(output, "Style/AndOr")
+        assert !includes_check?(output, "Lint/UselessAssignment")
+      end
+
       it "reads a file with a #!.*ruby declaration at the top" do
         create_source_file("my_script", <<-EORUBY)
           #!/usr/bin/env ruby


### PR DESCRIPTION
I was having issues and discovered that one of these test was a false positive. I then added another test to confirm that `.rubocop.yml` is used without specifying it in the config.