### PR TITLE
change monkey patch to use module_eval

### DIFF
--- a/lib/cc/engine/rubocop.rb
+++ b/lib/cc/engine/rubocop.rb
@@ -1,7 +1,7 @@
 require "json"
 require "pathname"
-require "rubocop/cop/method_complexity_patch"
 require "rubocop"
+require "rubocop/cop/method_complexity_patch"
 require "cc/engine/category_parser"
 
 module CC

--- a/lib/rubocop/cop/method_complexity_patch.rb
+++ b/lib/rubocop/cop/method_complexity_patch.rb
@@ -1,18 +1,14 @@
 # Monkey patching! Here be dragons.
-module RuboCop
-  module Cop
-    module MethodComplexity
-      # RuboCop's default implementation of `add_offense` in `Cop` only gets the
-      # location of the keyword associated with the problem which, for things
-      # like complexity checkers, is just the method def line. This isn't very
-      # useful for checkers where the entire method body is relevant. Fetching
-      # this information from an `Offense` instance is difficult, since the
-      # original AST is no longer available. So it's easier to monkey-path
-      # this method on complexity checkers to send the location of the entire
-      # method to the created `Offense`.
-      def add_offense(node, loc, message = nil, severity = nil)
-        super(node, node.loc, message, severity)
-      end
-    end
+RuboCop::Cop::MethodComplexity.module_eval do
+  # RuboCop's default implementation of `add_offense` in `Cop` only gets the
+  # location of the keyword associated with the problem which, for things
+  # like complexity checkers, is just the method def line. This isn't very
+  # useful for checkers where the entire method body is relevant. Fetching
+  # this information from an `Offense` instance is difficult, since the
+  # original AST is no longer available. So it's easier to monkey-path
+  # this method on complexity checkers to send the location of the entire
+  # method to the created `Offense`.
+  def add_offense(node, loc, message = nil, severity = nil)
+    super(node, node.loc, message, severity)
   end
 end


### PR DESCRIPTION
Bryan [suggested this](https://github.com/codeclimate/codeclimate-rubocop/pull/9#discussion-diff-37535714R4) as a refactor as it will fail faster if RuboCop changes in the future, and it will fail in a more obvious way (rather than just suddenly failing one of our analysis specs). Seems sound to me.

This won't affect current behavior, just guard a bit against future failure, so there's no rush in merging or deploying.