### PR TITLE
circleci: don't tag to git or deploy to docker hub

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,3 +20,7 @@ deployment:
       - gcloud auth activate-service-account --key-file /tmp/gcloud_key.json
       - gcloud docker -a
       - docker push $PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM
+
+notify:
+  webhooks:
+    - url: https://cc-slack-proxy.herokuapp.com/circle

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,6 @@ machine:
   environment:
     CLOUDSDK_CORE_DISABLE_PROMPTS: 1
     PRIVATE_REGISTRY: us.gcr.io/code_climate
-    PUBLIC_REGISTRY: hub.docker.com/codeclimate
 
 test:
   override:
@@ -20,7 +19,4 @@ deployment:
       - curl https://sdk.cloud.google.com | bash
       - gcloud auth activate-service-account --key-file /tmp/gcloud_key.json
       - gcloud docker -a
-      - git tag b$CIRCLE_BUILD_NUM master && git push origin b$CIRCLE_BUILD_NUM
       - docker push $PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM
-      - docker tag $PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM $PUBLIC_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM
-      - docker push $PUBLIC_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM


### PR DESCRIPTION
Doing all of this in Circle turned out to be a pain to get working correctly, and would have been even more of a pain to expand to other repos, so I'm backing out those bits.

Eventually, it would be good to have all of those various tasks centralized: once we do that elsewhere, we can remove the `deployment` bit entirely here. In the meantime, we should keep the existing behavior.