### PR TITLE
Removes non-Ruby files from include_path before passing to rubocop.

### DIFF
--- a/lib/cc/engine/file_list_resolver.rb
+++ b/lib/cc/engine/file_list_resolver.rb
@@ -1,0 +1,61 @@
+module CC
+  module Engine
+    class FileListResolver
+      def initialize(code:, engine_config: {}, rubocop_config_store:)
+        @code = code
+        @exclude_paths = engine_config["exclude_paths"] || []
+        @include_paths = engine_config["include_paths"]
+        @rubocop_config_store = rubocop_config_store
+      end
+
+      def expanded_list
+        if @include_paths
+          include_based_files_to_inspect
+        else
+          exclude_based_files_to_inspect
+        end
+      end
+
+      protected
+
+      def exclude_based_files_to_inspect
+        rubocop_runner.send(:find_target_files, []).reject do |path|
+          exclude_due_to_config?(path)
+        end
+      end
+
+      def exclude_due_to_config?(path)
+        @exclude_paths.include?(local_path(path))
+      end
+
+      def include_based_files_to_inspect
+        @include_paths.map do |path|
+          if path =~ %r{/$}
+            rubocop_runner.send(:find_target_files, [path])
+          elsif rubocop_file_to_include?(path)
+            path
+          end
+        end.flatten.compact
+      end
+
+      def local_path(path)
+        realpath = Pathname.new(@code).realpath.to_s
+        path.gsub(%r|^#{realpath}/|, '')
+      end
+
+      def rubocop_file_to_include?(file)
+        if file =~ /\.rb$/
+          true
+        else
+          dir = File.dirname(file)
+          basename = File.basename(file)
+          @rubocop_config_store.for(dir).file_to_include?(basename)
+        end
+      end
+
+      def rubocop_runner
+        @rubocop_runner ||= RuboCop::Runner.new({}, @rubocop_config_store)
+      end
+    end
+  end
+end

--- a/lib/cc/engine/file_list_resolver.rb
+++ b/lib/cc/engine/file_list_resolver.rb
@@ -16,7 +16,7 @@ module CC
         end
       end
 
-      protected
+      private
 
       def exclude_based_files_to_inspect
         rubocop_runner.send(:find_target_files, []).reject do |path|
@@ -47,8 +47,7 @@ module CC
         if file =~ /\.rb$/
           true
         else
-          dir = File.dirname(file)
-          basename = File.basename(file)
+          dir, basename = File.split(file)
           @rubocop_config_store.for(dir).file_to_include?(basename)
         end
       end

--- a/lib/cc/engine/rubocop.rb
+++ b/lib/cc/engine/rubocop.rb
@@ -3,6 +3,7 @@ require "pathname"
 require "rubocop"
 require "rubocop/cop/method_complexity_patch"
 require "cc/engine/category_parser"
+require "cc/engine/file_list_resolver"
 require "active_support"
 require "active_support/core_ext"
 
@@ -26,23 +27,15 @@ module CC
       private
 
       def files_to_inspect
-        runner = RuboCop::Runner.new({}, rubocop_config_store)
-        if @engine_config["include_paths"]
-          runner.send(:find_target_files, @engine_config["include_paths"])
-        else
-          runner.send(:find_target_files, []).reject do |path|
-            exclude_due_to_config?(path)
-          end
-        end
+        @file_list_resolver = FileListResolver.new(
+          code: @code, engine_config: @engine_config,
+          rubocop_config_store: rubocop_config_store
+        )
+        @file_list_resolver.expanded_list
       end
 
       def category(cop_name)
         CategoryParser.new(cop_name).category
-      end
-
-      def exclude_due_to_config?(path)
-        exclusions = @engine_config["exclude_paths"] || []
-        exclusions.include?(local_path(path))
       end
 
       def inspect_file(path)
@@ -60,11 +53,13 @@ module CC
 
       def rubocop_config_store
         @rubocop_config_store ||= begin
-          config_store = RuboCop::ConfigStore.new
-          if (config_file = @engine_config["config"])
-            config_store.options_config = config_file
+          Dir.chdir(@code) do
+            config_store = RuboCop::ConfigStore.new
+            if (config_file = @engine_config["config"])
+              config_store.options_config = config_file
+            end
+            config_store
           end
-          config_store
         end
       end
 

--- a/lib/cc/engine/rubocop.rb
+++ b/lib/cc/engine/rubocop.rb
@@ -28,7 +28,8 @@ module CC
 
       def files_to_inspect
         @file_list_resolver = FileListResolver.new(
-          code: @code, engine_config: @engine_config,
+          code: @code,
+          engine_config: @engine_config,
           rubocop_config_store: rubocop_config_store
         )
         @file_list_resolver.expanded_list

--- a/spec/cc/engine/rubocop_spec.rb
+++ b/spec/cc/engine/rubocop_spec.rb
@@ -243,11 +243,11 @@ module CC::Engine
         config_yml = "foo:\n  bar: \"baz\""
         create_source_file("config.yml", config_yml)
         output = run_engine(
-          "include_paths" => %w(config.yml)
+          "include_paths" => %w[config.yml]
         )
-        assert !issues(output).detect { |i| 
+        refute (issues(output).detect do |i| 
           i["description"] == "unexpected token tCOLON"
-        }
+        end)
       end
 
       it "includes Ruby files even if they don't end with .rb" do

--- a/spec/cc/engine/rubocop_spec.rb
+++ b/spec/cc/engine/rubocop_spec.rb
@@ -239,6 +239,29 @@ module CC::Engine
         assert !includes_check?(output, "Style/AndOr")
       end
 
+      it "ignores non-Ruby files even when passed in as include_paths" do
+        config_yml = "foo:\n  bar: \"baz\""
+        create_source_file("config.yml", config_yml)
+        output = run_engine(
+          "include_paths" => %w(config.yml)
+        )
+        assert !issues(output).detect { |i| 
+          i["description"] == "unexpected token tCOLON"
+        }
+      end
+
+      it "includes Ruby files even if they don't end with .rb" do
+        create_source_file("Rakefile", <<-EORUBY)
+          def method
+            unused = "x"
+
+            return false
+          end
+        EORUBY
+        output = run_engine("include_paths" => %w(Rakefile))
+        assert includes_check?(output, "Lint/UselessAssignment")
+      end
+
       def includes_check?(output, cop_name)
         !!issues(output).detect { |i| i["check_name"] =~ /#{cop_name}$/ }
       end


### PR DESCRIPTION
cc @codeclimate/review 