### PR TITLE
Add RuboCop configuration and basic style corrections

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,19 @@
+Metrics/ModuleLength:
+  Exclude:
+    - 'spec/**/*'
+Style/ClassAndModuleChildren:
+  Exclude:
+    - 'spec/**/*'
+Style/Documentation:
+  Enabled: false
+Style/FileName:
+  Exclude:
+    - 'bin/codeclimate-rubocop'
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%w': '[]'
+    '%W': '[]'
+Style/StringLiterals:
+  Enabled: false
+Style/TrailingComma:
+  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'rake/testtask'
 
 Rake::TestTask.new do |t|
   t.test_files = Dir.glob('spec/**/*_spec.rb')
-  t.libs = ["lib", "spec"]
+  t.libs = %w[lib spec]
 end
 
 task(default: :test)

--- a/bin/codeclimate-rubocop
+++ b/bin/codeclimate-rubocop
@@ -1,9 +1,11 @@
 #!/usr/bin/env ruby
-$LOAD_PATH.unshift(File.expand_path(File.join(File.dirname(__FILE__), "../lib")))
+$LOAD_PATH.unshift(
+  File.expand_path(File.join(File.dirname(__FILE__), "../lib"))
+)
 
 require 'cc/engine/rubocop'
 
-if File.exists?("/config.json")
+if File.exist?("/config.json")
   engine_config = JSON.parse(File.read("/config.json"))
 else
   engine_config = {}

--- a/lib/cc/engine/file_list_resolver.rb
+++ b/lib/cc/engine/file_list_resolver.rb
@@ -40,7 +40,7 @@ module CC
 
       def local_path(path)
         realpath = Pathname.new(@code).realpath.to_s
-        path.gsub(%r|^#{realpath}/|, '')
+        path.gsub(%r{^#{realpath}/}, '')
       end
 
       def rubocop_file_to_include?(file)

--- a/lib/cc/engine/rubocop.rb
+++ b/lib/cc/engine/rubocop.rb
@@ -49,7 +49,7 @@ module CC
 
       def local_path(path)
         realpath = Pathname.new(@code).realpath.to_s
-        path.gsub(%r|^#{realpath}/|, '')
+        path.gsub(%r{^#{realpath}/}, '')
       end
 
       def rubocop_config_store
@@ -83,7 +83,7 @@ module CC
         end
 
         {
-          begin:  {
+          begin: {
             column: first_column + 1, # columns are 0-based in Parser
             line: first_line,
           },
@@ -112,7 +112,9 @@ module CC
       end
 
       def content_body(cop_name)
-        path = File.expand_path("../../../../config/contents/#{cop_name.underscore}.md", __FILE__)
+        path = File.expand_path(
+          "../../../../config/contents/#{cop_name.underscore}.md", __FILE__
+        )
         File.exist?(path) ? File.read(path) : nil
       end
     end

--- a/lib/rubocop/cop/method_complexity_patch.rb
+++ b/lib/rubocop/cop/method_complexity_patch.rb
@@ -8,7 +8,7 @@ RuboCop::Cop::MethodComplexity.module_eval do
   # original AST is no longer available. So it's easier to monkey-path
   # this method on complexity checkers to send the location of the entire
   # method to the created `Offense`.
-  def add_offense(node, loc, message = nil, severity = nil)
+  def add_offense(node, _loc, message = nil, severity = nil)
     super(node, node.loc, message, severity)
   end
 end

--- a/spec/cc/engine/rubocop_spec.rb
+++ b/spec/cc/engine/rubocop_spec.rb
@@ -133,11 +133,17 @@ module CC::Engine
       end
 
       it "handles different locations properly" do
-        RuboCop::Cop::Team.any_instance.expects(:inspect_file).returns([OpenStruct.new(
-          location: RuboCop::Cop::Lint::Syntax::PseudoSourceRange.new(1, 0, ""),
-          cop_name: "fake",
-          message: "message"
-        )])
+        RuboCop::Cop::Team.any_instance.expects(:inspect_file).returns(
+          [
+            OpenStruct.new(
+              location: RuboCop::Cop::Lint::Syntax::PseudoSourceRange.new(
+                1, 0, ""
+              ),
+              cop_name: "fake",
+              message: "message"
+            )
+          ]
+        )
         create_source_file("my_script.rb", <<-EORUBY)
           #!/usr/bin/env ruby
 
@@ -154,8 +160,8 @@ module CC::Engine
         location = {
           "path" => "my_script.rb",
           "positions" => {
-            "begin" => { "column"=>1, "line"=>1 },
-            "end" => { "column"=>1, "line"=>1 }
+            "begin" => { "column" => 1, "line" => 1 },
+            "end" => { "column" => 1, "line" => 1 }
           }
         }
         assert_equal location, result["location"]
@@ -190,12 +196,14 @@ module CC::Engine
 
         json = JSON.parse('[' + output.split("\u0000").join(',') + ']')
 
-        result = json.select { |i| i && i["check_name"] =~ /Metrics\/CyclomaticComplexity/ }.first
+        result = json.find do |i|
+          i && i["check_name"] =~ %r{Metrics\/CyclomaticComplexity}
+        end
         location = {
           "path" => "my_script",
           "positions" => {
-            "begin" => { "column"=>11, "line"=>3 },
-            "end" => { "column"=>14, "line"=>21 }
+            "begin" => { "column" => 11, "line" => 3 },
+            "end" => { "column" => 14, "line" => 21 }
           }
         }
         assert_equal location, result["location"]
@@ -233,7 +241,7 @@ module CC::Engine
           end
         EORUBY
         output = run_engine(
-          "include_paths" => %w(included_root_file.rb subdir/)
+          "include_paths" => %w[included_root_file.rb subdir/]
         )
         assert !includes_check?(output, "Lint/UselessAssignment")
         assert !includes_check?(output, "Style/AndOr")
@@ -245,7 +253,7 @@ module CC::Engine
         output = run_engine(
           "include_paths" => %w[config.yml]
         )
-        refute (issues(output).detect do |i| 
+        refute(issues(output).detect do |i|
           i["description"] == "unexpected token tCOLON"
         end)
       end
@@ -258,12 +266,12 @@ module CC::Engine
             return false
           end
         EORUBY
-        output = run_engine("include_paths" => %w(Rakefile))
+        output = run_engine("include_paths" => %w[Rakefile])
         assert includes_check?(output, "Lint/UselessAssignment")
       end
 
       def includes_check?(output, cop_name)
-        !!issues(output).detect { |i| i["check_name"] =~ /#{cop_name}$/ }
+        issues(output).any? { |i| i["check_name"] =~ /#{cop_name}$/ }
       end
 
       def includes_content_for?(output, cop_name)


### PR DESCRIPTION
It seems only fitting that the RuboCop engine should pass its own checks!

I added a minimal configuration based on the current code, then ran
RuboCop using the `-a` (autocorrect) option.

The only non-stylistic change I made was to use an `any?` block in place
of a `detect` block combined with `!!`.

There are two violations remaining, both about method length, but
since there’s a little more involved I’ve left them alone.