### PR TITLE
Extract `ViolationHash` class

### DIFF
--- a/lib/cc/engine/rubocop.rb
+++ b/lib/cc/engine/rubocop.rb
@@ -2,10 +2,8 @@ require "json"
 require "pathname"
 require "rubocop"
 require "rubocop/cop/method_complexity_patch"
-require "cc/engine/category_parser"
 require "cc/engine/file_list_resolver"
-require "active_support"
-require "active_support/core_ext"
+require "cc/engine/violation_hash"
 
 module CC
   module Engine
@@ -35,14 +33,10 @@ module CC
         @file_list_resolver.expanded_list
       end
 
-      def category(cop_name)
-        CategoryParser.new(cop_name).category
-      end
-
       def inspect_file(path)
         parsed = RuboCop::ProcessedSource.from_file(path)
         rubocop_team_for_path(path).inspect_file(parsed).each do |violation|
-          json = violation_json(violation, local_path(path))
+          json = ViolationHash.new(violation, local_path(path)).to_json
           @io.print "#{json}\0"
         end
       end
@@ -67,55 +61,6 @@ module CC
       def rubocop_team_for_path(path)
         rubocop_config = rubocop_config_store.for(path)
         RuboCop::Cop::Team.new(RuboCop::Cop::Cop.all, rubocop_config)
-      end
-
-      def violation_positions(location)
-        if location.is_a?(RuboCop::Cop::Lint::Syntax::PseudoSourceRange)
-          first_line = location.line
-          last_line = location.line
-          first_column = location.column
-          last_column = location.column
-        else
-          first_line = location.first_line
-          last_line = location.last_line
-          first_column = location.column
-          last_column = location.last_column
-        end
-
-        {
-          begin: {
-            column: first_column + 1, # columns are 0-based in Parser
-            line: first_line,
-          },
-          end: {
-            column: last_column + 1,
-            line: last_line,
-          }
-        }
-      end
-
-      def violation_json(violation, local_path)
-        violation_hash = {
-          type: "Issue",
-          check_name: "Rubocop/#{violation.cop_name}",
-          description: violation.message,
-          categories: [category(violation.cop_name)],
-          remediation_points: 50_000,
-          location: {
-            path: local_path,
-            positions: violation_positions(violation.location),
-          },
-        }
-        body = content_body(violation.cop_name)
-        violation_hash.merge!(content: { body: body }) if body.present?
-        violation_hash.to_json
-      end
-
-      def content_body(cop_name)
-        path = File.expand_path(
-          "../../../../config/contents/#{cop_name.underscore}.md", __FILE__
-        )
-        File.exist?(path) ? File.read(path) : nil
       end
     end
   end

--- a/lib/cc/engine/violation_hash.rb
+++ b/lib/cc/engine/violation_hash.rb
@@ -1,0 +1,72 @@
+require "rubocop"
+require "active_support"
+require "active_support/core_ext"
+require "cc/engine/category_parser"
+
+module CC
+  module Engine
+    class ViolationHash
+      def initialize(violation, local_path)
+        @violation = violation
+        @local_path = local_path
+      end
+
+      def to_json
+        result = {
+          type: "Issue",
+          check_name: "Rubocop/#{violation.cop_name}",
+          description: violation.message,
+          categories: [category(violation.cop_name)],
+          remediation_points: 50_000,
+          location: {
+            path: local_path,
+            positions: violation_positions(violation.location),
+          },
+        }
+        body = content_body(violation.cop_name)
+        result.merge!(content: { body: body }) if body.present?
+        result.to_json
+      end
+
+      private
+
+      attr_reader :violation, :local_path
+
+      def category(cop_name)
+        CategoryParser.new(cop_name).category
+      end
+
+      def violation_positions(location)
+        if location.is_a?(RuboCop::Cop::Lint::Syntax::PseudoSourceRange)
+          first_line = location.line
+          last_line = location.line
+          first_column = location.column
+          last_column = location.column
+        else
+          first_line = location.first_line
+          last_line = location.last_line
+          first_column = location.column
+          last_column = location.last_column
+        end
+
+        {
+          begin: {
+            column: first_column + 1, # columns are 0-based in Parser
+            line: first_line,
+          },
+          end: {
+            column: last_column + 1,
+            line: last_line,
+          }
+        }
+      end
+
+      def content_body(cop_name)
+        path = File.expand_path(
+          "../../../../config/contents/#{cop_name.underscore}.md", __FILE__
+        )
+        File.exist?(path) ? File.read(path) : nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
I've been studying the RuboCop engine as I work on an engine for Reek.

There's a lot happening in `rubocop.rb`, with many mixed levels of
abstraction. It seems that extracting out the responsibility of
building the violation hash would make things easier to understand and
maintain.

I've not yet updated the tests to reflect the new structure. I'll await
feedback on this proposal first.