### PR TITLE
Conditionally include Rails cops

### DIFF
--- a/lib/cc/engine/lockfile_specs.rb
+++ b/lib/cc/engine/lockfile_specs.rb
@@ -1,0 +1,18 @@
+require "bundler/lockfile_parser"
+
+class LockfileSpecs
+  def initialize(lockfile)
+    if File.exist?(lockfile)
+      @contents = File.read(lockfile)
+    else
+      @contents = ""
+    end
+  end
+
+  def include?(name)
+    @lockfile ||= Bundler::LockfileParser.new(@contents)
+    @lockfile.specs.any? { |spec| spec.name == name }
+  rescue Bundler::LockfileError
+    false
+  end
+end

--- a/lib/cc/engine/rubocop.rb
+++ b/lib/cc/engine/rubocop.rb
@@ -4,6 +4,7 @@ require "rubocop"
 require "rubocop/cop/method_complexity_patch"
 require "cc/engine/category_parser"
 require "cc/engine/file_list_resolver"
+require "cc/engine/lockfile_specs"
 require "active_support"
 require "active_support/core_ext"
 
@@ -66,7 +67,7 @@ module CC
 
       def rubocop_team_for_path(path)
         rubocop_config = rubocop_config_store.for(path)
-        RuboCop::Cop::Team.new(RuboCop::Cop::Cop.all, rubocop_config)
+        RuboCop::Cop::Team.new(cops, rubocop_config)
       end
 
       def violation_positions(location)
@@ -116,6 +117,16 @@ module CC
           "../../../../config/contents/#{cop_name.underscore}.md", __FILE__
         )
         File.exist?(path) ? File.read(path) : nil
+      end
+
+      def cops
+        specs = LockfileSpecs.new("Gemfile.lock")
+
+        if specs.include?("railties")
+          RuboCop::Cop::Cop.all
+        else
+          RuboCop::Cop::Cop.non_rails
+        end
       end
     end
   end

--- a/spec/cc/engine/lockfile_specs_spec.rb
+++ b/spec/cc/engine/lockfile_specs_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+require "cc/engine/lockfile_specs"
+
+module CC::Engine
+  describe LockfileSpecs do
+    describe "#include?" do
+      before do
+        @specs = LockfileSpecs.new("./spec/fixtures/Gemfile.lock")
+      end
+
+      it "returns true when spec is include in Gemfile.lock" do
+        @specs.include?("ansi").must_equal(true)
+        @specs.include?("i18n").must_equal(true)
+        @specs.include?("astrolabe").must_equal(true)
+      end
+
+      it "returns false when spec not include in Gemfile.lock" do
+        @specs.include?("railties").must_equal(false)
+        @specs.include?("pants").must_equal(false)
+        @specs.include?("python").must_equal(false)
+      end
+
+      it "returns false when a LockfileError occurs while parsing" do
+        fixture = "./spec/fixtures/Gemfile.lock.with_merge_conflicts"
+        specs = LockfileSpecs.new(fixture)
+
+        specs.include?("ansi").must_equal(false)
+      end
+
+      it "returns false when no Gemfile.lock file is found" do
+        specs = LockfileSpecs.new(SecureRandom.hex(32))
+
+        specs.include?("ansi").must_equal(false)
+      end
+    end
+  end
+end

--- a/spec/cc/engine/rubocop_spec.rb
+++ b/spec/cc/engine/rubocop_spec.rb
@@ -110,6 +110,79 @@ module CC::Engine
         assert !includes_check?(output, "Lint/UselessAssignment")
       end
 
+      it "excludes Rails cops when there is no Gemfile.lock file present" do
+        create_source_file("object.rb", <<-EORUBY)
+          class Object
+            def method
+              target.method
+            end
+          end
+        EORUBY
+
+        assert !includes_check?(run_engine, "Rubocop/Rails/Delegate")
+      end
+
+      it "excludes Rails cops when railties isn't in the Gemfile.lock file" do
+        create_source_file("object.rb", <<-EORUBY)
+          class Object
+            def method
+              target.method
+            end
+          end
+        EORUBY
+
+        create_source_file("Gemfile.lock", <<-EORUBY.strip_heredoc)
+          GEM
+            remote: https://rubygems.org/
+            specs:
+              rake (10.4.2)
+        EORUBY
+
+        assert !includes_check?(run_engine, "Rubocop/Rails/Delegate")
+      end
+
+      it "excludes Rails cops when there is no valid Gemfile.lock file" do
+        create_source_file("object.rb", <<-EORUBY)
+          class Object
+            def method
+              target.method
+            end
+          end
+        EORUBY
+
+        # This will create a parse error as Bundler::LockfileParser looks
+        # specifically for merge conflict artifacts and bails.
+        create_source_file("Gemfile.lock", <<-EORUBY.strip_heredoc)
+          <<<<<<< HEAD
+          =======
+          GEM
+            remote: https://rubygems.org/
+            specs:
+              rake (10.4.2)
+        EORUBY
+
+        assert !includes_check?(run_engine, "Rubocop/Rails/Delegate")
+      end
+
+      it "includes Rails cops when railties is in the Gemfile.lock file" do
+        create_source_file("object.rb", <<-EORUBY)
+          class Object
+            def method
+              target.method
+            end
+          end
+        EORUBY
+
+        create_source_file("Gemfile.lock", <<-EORUBY.strip_heredoc)
+          GEM
+            remote: https://rubygems.org/
+            specs:
+              railties (4.2.4)
+        EORUBY
+
+        assert includes_check?(run_engine, "Rubocop/Rails/Delegate")
+      end
+
       it "layers config exclusions on top of the YAML config" do
         create_source_file("foo.rb", <<-EORUBY)
           def method

--- a/spec/fixtures/Gemfile.lock
+++ b/spec/fixtures/Gemfile.lock
@@ -1,0 +1,61 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (4.2.4)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    ansi (1.5.0)
+    ast (2.1.0)
+    astrolabe (1.3.1)
+      parser (~> 2.2)
+    builder (3.2.2)
+    coderay (1.1.0)
+    i18n (0.7.0)
+    json (1.8.3)
+    metaclass (0.0.4)
+    method_source (0.8.2)
+    minitest (5.8.0)
+    minitest-reporters (1.0.20)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
+    parser (2.2.2.6)
+      ast (>= 1.1, < 3.0)
+    powerpack (0.1.1)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    rainbow (2.0.0)
+    rake (10.4.2)
+    rubocop (0.33.0)
+      astrolabe (~> 1.3)
+      parser (>= 2.2.2.5, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.4)
+    rubocop-rspec (1.3.0)
+    ruby-progressbar (1.7.5)
+    slop (3.6.0)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activesupport
+  minitest
+  minitest-reporters
+  mocha
+  pry
+  rake
+  rubocop
+  rubocop-rspec

--- a/spec/fixtures/Gemfile.lock.with_merge_conflicts
+++ b/spec/fixtures/Gemfile.lock.with_merge_conflicts
@@ -1,0 +1,64 @@
+GEM
+<<<<<<< HEAD
+  remote: https://rubygems.org/
+=======
+>>>>>>> 97cefa491ac4217bdee8557c84f3657355f9b049
+  specs:
+    activesupport (4.2.4)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    ansi (1.5.0)
+    ast (2.1.0)
+    astrolabe (1.3.1)
+      parser (~> 2.2)
+    builder (3.2.2)
+    coderay (1.1.0)
+    i18n (0.7.0)
+    json (1.8.3)
+    metaclass (0.0.4)
+    method_source (0.8.2)
+    minitest (5.8.0)
+    minitest-reporters (1.0.20)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
+    parser (2.2.2.6)
+      ast (>= 1.1, < 3.0)
+    powerpack (0.1.1)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    rainbow (2.0.0)
+    rake (10.4.2)
+    rubocop (0.33.0)
+      astrolabe (~> 1.3)
+      parser (>= 2.2.2.5, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.4)
+    rubocop-rspec (1.3.0)
+    ruby-progressbar (1.7.5)
+    slop (3.6.0)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activesupport
+  minitest
+  minitest-reporters
+  mocha
+  pry
+  rake
+  rubocop
+  rubocop-rspec


### PR DESCRIPTION
Only include the Rails-specific cops if we see railties in the Gemfile.lock file in the project. This should resolve cases where Rails-specific advice is given for projects that aren't using Rails (e.g. Rails/Delegate).