### PR TITLE
Add bundler to Gemfile and require for LockfileParser dependencies

### DIFF
--- a/lib/cc/engine/lockfile_specs.rb
+++ b/lib/cc/engine/lockfile_specs.rb
@@ -1,4 +1,4 @@
-require "bundler/lockfile_parser"
+require "bundler"
 
 class LockfileSpecs
   def initialize(lockfile)


### PR DESCRIPTION
I'm running into the following error while running this engine locally through the platform. Looks like the `LockfileParser` depends upon some other classes defined in bundler that aren't brought in unless you `require "bundler"`.

```
/usr/lib/ruby/gems/2.2.0/gems/bundler-1.10.5/lib/bundler/lockfile_parser.rb:86:in `<class:LockfileParser>': uninitialized constant Bundler::Source (NameError)
	from /usr/lib/ruby/gems/2.2.0/gems/bundler-1.10.5/lib/bundler/lockfile_parser.rb:14:in `<module:Bundler>'
	from /usr/lib/ruby/gems/2.2.0/gems/bundler-1.10.5/lib/bundler/lockfile_parser.rb:13:in `<top (required)>'
	from /usr/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:128:in `require'
	from /usr/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:128:in `rescue in require'
	from /usr/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:39:in `require'
	from /usr/src/app/lib/cc/engine/lockfile_specs.rb:1:in `<top (required)>'
	from /usr/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /usr/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /usr/src/app/lib/cc/engine/rubocop.rb:7:in `<top (required)>'
	from /usr/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /usr/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /usr/src/app/bin/codeclimate-rubocop:6:in `<main>'
```

@codeclimate/review :mag_right: 