### PR TITLE
lockfile: fix no-Gemfile case

### DIFF
--- a/lib/cc/engine/lockfile_specs.rb
+++ b/lib/cc/engine/lockfile_specs.rb
@@ -2,14 +2,11 @@ require "bundler"
 
 class LockfileSpecs
   def initialize(lockfile)
-    if File.exist?(lockfile)
-      @contents = File.read(lockfile)
-    else
-      @contents = ""
-    end
+    @contents = File.read(lockfile) if File.exist?(lockfile)
   end
 
   def include?(name)
+    return false if @contents.nil?
     @lockfile ||= Bundler::LockfileParser.new(@contents)
     @lockfile.specs.any? { |spec| spec.name == name }
   rescue Bundler::LockfileError


### PR DESCRIPTION
I was seeing a crash locally analyzing a repo with no Gemfile. It appears that Bundler's LockfileParser was actually trying to read a file somewhere even though we gave it string contents.

This changes the no-file behavior to be a harder short-circuit, so Bundler's class is never even instantiated.

I believe that we're not seeing this in production because production looks like it's still using [`b18`](https://github.com/codeclimate/builder/blob/master/config/engines.yml#L1-L2).

I believe the specs were passing because we were probably using a slightly different version of bundler there. I'm not certain, though. Similar to the last fix for this, this is not very unit-testable.

The stack trace:
```
/usr/lib/ruby/gems/2.2.0/gems/bundler-1.10.5/lib/bundler.rb:198:in `rescue in root': Could not locate Gemfile or .bundle/ directory (Bundler::GemfileNotFound)
	from /usr/lib/ruby/gems/2.2.0/gems/bundler-1.10.5/lib/bundler.rb:194:in `root'
	from /usr/lib/ruby/gems/2.2.0/gems/bundler-1.10.5/lib/bundler.rb:210:in `app_cache'
	from /usr/lib/ruby/gems/2.2.0/gems/bundler-1.10.5/lib/bundler/source/rubygems.rb:23:in `initialize'
	from /usr/lib/ruby/gems/2.2.0/gems/bundler-1.10.5/lib/bundler/lockfile_parser.rb:34:in `new'
	from /usr/lib/ruby/gems/2.2.0/gems/bundler-1.10.5/lib/bundler/lockfile_parser.rb:34:in `initialize'
	from /usr/src/app/lib/cc/engine/lockfile_specs.rb:13:in `new'
	from /usr/src/app/lib/cc/engine/lockfile_specs.rb:13:in `include?'
	from /usr/src/app/lib/cc/engine/rubocop.rb:126:in `cops'
	from /usr/src/app/lib/cc/engine/rubocop.rb:71:in `rubocop_team_for_path'
	from /usr/src/app/lib/cc/engine/rubocop.rb:46:in `inspect_file'
	from /usr/src/app/lib/cc/engine/rubocop.rb:23:in `block (2 levels) in run'
	from /usr/src/app/lib/cc/engine/rubocop.rb:22:in `each'
	from /usr/src/app/lib/cc/engine/rubocop.rb:22:in `block in run'
	from /usr/src/app/lib/cc/engine/rubocop.rb:21:in `chdir'
	from /usr/src/app/lib/cc/engine/rubocop.rb:21:in `run'
	from /usr/src/app/bin/codeclimate-rubocop:14:in `<main>'
```

:eyes: @codeclimate/review @dblandin