### PR TITLE
Add configurable remediation points from yaml

### DIFF
--- a/config/cops.yml
+++ b/config/cops.yml
@@ -1,0 +1,1 @@
+Metrics/ClassLength: 400_000


### PR DESCRIPTION
This adds `config/cops.yml` which contains the configuration of the
points that each cop should return.

This also ups the default remediation points value to `200,000` from `50,000` since the previous value was too small to affect ratings.