### PR TITLE
Use Regexp match to detect gem

### DIFF
--- a/lib/cc/engine/lockfile_specs.rb
+++ b/lib/cc/engine/lockfile_specs.rb
@@ -1,15 +1,13 @@
-require "bundler"
-
 class LockfileSpecs
   def initialize(lockfile)
-    @contents = File.read(lockfile) if File.exist?(lockfile)
+    @lockfile = lockfile
   end
 
   def include?(name)
-    return false if @contents.nil?
-    @lockfile ||= Bundler::LockfileParser.new(@contents)
-    @lockfile.specs.any? { |spec| spec.name == name }
-  rescue Bundler::LockfileError
-    false
+    return false unless File.exist?(@lockfile)
+
+    File.open(@lockfile) do |file|
+      file.each_line.any? { |line| line =~ /#{name}/ }
+    end
   end
 end

--- a/spec/cc/engine/lockfile_specs_spec.rb
+++ b/spec/cc/engine/lockfile_specs_spec.rb
@@ -20,13 +20,6 @@ module CC::Engine
         @specs.include?("python").must_equal(false)
       end
 
-      it "returns false when a LockfileError occurs while parsing" do
-        fixture = "./spec/fixtures/Gemfile.lock.with_merge_conflicts"
-        specs = LockfileSpecs.new(fixture)
-
-        specs.include?("ansi").must_equal(false)
-      end
-
       it "returns false when no Gemfile.lock file is found" do
         specs = LockfileSpecs.new(SecureRandom.hex(32))
 

--- a/spec/cc/engine/rubocop_spec.rb
+++ b/spec/cc/engine/rubocop_spec.rb
@@ -141,29 +141,6 @@ module CC::Engine
         assert !includes_check?(run_engine, "Rubocop/Rails/Delegate")
       end
 
-      it "excludes Rails cops when there is no valid Gemfile.lock file" do
-        create_source_file("object.rb", <<-EORUBY)
-          class Object
-            def method
-              target.method
-            end
-          end
-        EORUBY
-
-        # This will create a parse error as Bundler::LockfileParser looks
-        # specifically for merge conflict artifacts and bails.
-        create_source_file("Gemfile.lock", <<-EORUBY.strip_heredoc)
-          <<<<<<< HEAD
-          =======
-          GEM
-            remote: https://rubygems.org/
-            specs:
-              rake (10.4.2)
-        EORUBY
-
-        assert !includes_check?(run_engine, "Rubocop/Rails/Delegate")
-      end
-
       it "includes Rails cops when railties is in the Gemfile.lock file" do
         create_source_file("object.rb", <<-EORUBY)
           class Object


### PR DESCRIPTION
It turns out coupling to Bundler::LockfileParser was a bad idea
and has caused odd behavior in practice. This change simplies
the approach and just looks through the lines of the raw
Gemfile.lock and looks for railties instead of using any
bundler components.

cc @wfleming 