### PR TITLE
Allow remediation points to be multipliable

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,9 @@ Metrics/ModuleLength:
 Style/ClassAndModuleChildren:
   Exclude:
     - 'spec/**/*'
+Metrics/LineLength:
+  Exclude:
+    - 'spec/**/*'
 Style/Documentation:
   Enabled: false
 Style/FileName:
@@ -16,4 +19,9 @@ Style/PercentLiteralDelimiters:
 Style/StringLiterals:
   Enabled: false
 Style/TrailingComma:
+  Enabled: false
+Style/DotPosition:
+  EnforcedStyle: 'trailing'
+  Enabled: true
+Style/MultilineOperationIndentation:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem "activesupport", require: false
 gem "rubocop", require: false
 gem "rubocop-rspec", require: false
+gem "safe_yaml"
 gem "pry", require: false
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,7 @@ GEM
       ruby-progressbar (~> 1.4)
     rubocop-rspec (1.3.0)
     ruby-progressbar (1.7.5)
+    safe_yaml (1.0.4)
     slop (3.6.0)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
@@ -59,3 +60,4 @@ DEPENDENCIES
   rake
   rubocop
   rubocop-rspec
+  safe_yaml

--- a/config/cops.yml
+++ b/config/cops.yml
@@ -1,1 +1,24 @@
-Metrics/ClassLength: 400_000
+Metrics/AbcSize:
+  violation_points: 100_000
+Metrics/BlockNesting:
+  base_points: 30_000
+Metrics/ClassLength:
+  base_points: 400_000
+Metrics/CyclomaticComplexity:
+  base_points: 75_000
+  violation_points: 10_000
+Metrics/LineLength:
+  base_points: 20_000
+  violation_points: 5_000
+Metrics/MethodLength:
+  base_points: 50_000
+  violation_points: 10_000
+Metrics/ModuleLength:
+  base_points: 500_000
+  violation_points: 5_000
+Metrics/ParameterList:
+  base_points: 10_000
+  violation_points: 50_000
+Metrics/PerceivedComplexity:
+  base_points: 50_000
+  violation_points: 5000

--- a/lib/cc/engine/violation_decorator.rb
+++ b/lib/cc/engine/violation_decorator.rb
@@ -1,0 +1,56 @@
+require 'safe_yaml'
+
+module CC
+  module Engine
+    class ViolationDecorator < SimpleDelegator
+      MULTIPLIER_REGEX = %r{\[([\d\.]+)\/([\d\.]+)\]}
+
+      DEFAULT_REMEDIATION_POINTS = 200_000
+      DEFAULT_POINTS_PER_VIOLATION = 50_000
+
+      def remediation_points
+        if multiplier?
+          base_points + violation_points
+        else
+          base_points
+        end
+      end
+
+      private
+
+      def base_points
+        cop_list.
+          fetch(cop_name, {}).
+          fetch("base_points", DEFAULT_REMEDIATION_POINTS)
+      end
+
+      def violation_points
+        per_violation_points = cop_list.
+          fetch(cop_name, {}).
+          fetch("violation_points", DEFAULT_POINTS_PER_VIOLATION)
+
+        per_violation_points * multiplier
+      end
+
+      def multiplier
+        result = message.scan(MULTIPLIER_REGEX)
+        score, max = result[0]
+        score.to_i - max.to_i
+      end
+
+      def multiplier?
+        message.match(MULTIPLIER_REGEX)
+      end
+
+      def cop_list
+        return @cop_list if @cop_list
+
+        cops_path = File.expand_path(
+          File.join(File.dirname(__FILE__), "../../../config/cops.yml")
+        )
+
+        @cop_list = YAML.load_file(cops_path)
+      end
+    end
+  end
+end

--- a/spec/cc/engine/violation_decorator_spec.rb
+++ b/spec/cc/engine/violation_decorator_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+require "cc/engine/violation_decorator"
+
+module CC::Engine
+  describe ViolationDecorator do
+    describe "#remediation points" do
+      it "returns remediation points for violation" do
+        fake_violation = Minitest::Mock.new
+        fake_violation.expect :cop_name, :unknown_cop
+        fake_violation.expect :message, "This has no multiplier!"
+
+        decorated_violation = ViolationDecorator.new(fake_violation)
+
+        decorated_violation.remediation_points.must_equal(
+          ViolationDecorator::DEFAULT_REMEDIATION_POINTS
+        )
+      end
+
+      it "returns remedation points plus per violation points multiplied by overage" do
+        fake_violation = Minitest::Mock.new
+        fake_violation.expect :cop_name, :unknown_cop
+        fake_violation.expect :cop_name, :unknown_cop
+        fake_violation.expect :message, "This has [22/20] multiplier!"
+        fake_violation.expect :message, "This has [22/20] multiplier!"
+
+        decorated_violation = ViolationDecorator.new(fake_violation)
+
+        violation_pointss = ViolationDecorator::DEFAULT_POINTS_PER_VIOLATION * 2
+        base_points = ViolationDecorator::DEFAULT_REMEDIATION_POINTS
+
+        decorated_violation.remediation_points.must_equal(
+          violation_pointss + base_points
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a check for the format of `[score/limit]` in a cop message and
will extract the `score` value and multiply it by the defined remediation
points.

Remediation points for metric cops were also tweaked to make up for the addition of multiplication.