### PR TITLE
Run docker build as a dependency, not a test step

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,9 +5,12 @@ machine:
     CLOUDSDK_CORE_DISABLE_PROMPTS: 1
     PRIVATE_REGISTRY: us.gcr.io/code_climate
 
-test:
+dependencies:
   override:
     - docker build -t=$PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM .
+
+test:
+  override:
     - docker run $PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM bundle exec rake
 
 deployment:


### PR DESCRIPTION
Not overriding the dependency step can cause Circle to infer ruby and run a
bundle install. That can leave files in the source tree that end up copied into
the docker image and mess with bundler's operation within that image.

Also, the build step is (IMO) a dependency, not itself a test.

/cc @codeclimate/review -- open to opinions here