### PR TITLE
SafeYAML: set safe mode by default

### DIFF
--- a/lib/cc/engine/violation_decorator.rb
+++ b/lib/cc/engine/violation_decorator.rb
@@ -1,4 +1,5 @@
 require 'safe_yaml'
+SafeYAML::OPTIONS[:default_mode] = :safe
 
 module CC
   module Engine


### PR DESCRIPTION
we're loading SafeYAML, but then don't actually specify safe mode when
loading. We should just set it to the default when we load it.

cc @codeclimate/review