### PR TITLE
Skip locally disabled cops

### DIFF
--- a/lib/cc/engine/rubocop.rb
+++ b/lib/cc/engine/rubocop.rb
@@ -43,6 +43,7 @@ module CC
       def inspect_file(path)
         parsed = RuboCop::ProcessedSource.from_file(path)
         rubocop_team_for_path(path).inspect_file(parsed).each do |violation|
+          next if violation.disabled?
           decorated_violation = ViolationDecorator.new(violation)
           json = violation_json(decorated_violation, local_path(path))
           @io.print "#{json}\0"

--- a/spec/cc/engine/rubocop_spec.rb
+++ b/spec/cc/engine/rubocop_spec.rb
@@ -270,6 +270,19 @@ module CC::Engine
         assert includes_check?(output, "Lint/UselessAssignment")
       end
 
+      it "skips local disables" do
+        create_source_file("test.rb", <<-EORUBY)
+          def method
+            # rubocop:disable UselessAssignment
+            unused = "x"
+
+            return false
+          end
+        EORUBY
+        output = run_engine
+        refute includes_check?(output, "Lint/UselessAssignment")
+      end
+
       def includes_check?(output, cop_name)
         issues(output).any? { |i| i["check_name"] =~ /#{cop_name}$/ }
       end


### PR DESCRIPTION
When a line is skipped locally using Rubocops local disable we don't
want to report it. Rubocop offenses give us the `disabled?` method to
check if a violation was skipped locally.