### PR TITLE
Tune remediation points

### DIFF
--- a/config/cops.yml
+++ b/config/cops.yml
@@ -1,24 +1,25 @@
 Metrics/AbcSize:
-  violation_points: 100_000
+  base_points: 1_000_000
+  violation_points: 70_000
 Metrics/BlockNesting:
-  base_points: 30_000
+  base_points: 100_000
 Metrics/ClassLength:
-  base_points: 400_000
-Metrics/CyclomaticComplexity:
-  base_points: 75_000
-  violation_points: 10_000
+  base_points: 5_000_000
+  violation_points: 35_000
+Metrics/CyclomaticComplexity: # This check is per method
+  base_points: 1_000_000
+  violation_points: 70_000
 Metrics/LineLength:
-  base_points: 20_000
-  violation_points: 5_000
+  base_points: 50_000
 Metrics/MethodLength:
-  base_points: 50_000
-  violation_points: 10_000
+  base_points: 1_000_000
+  violation_points: 70_000
 Metrics/ModuleLength:
-  base_points: 500_000
-  violation_points: 5_000
+  base_points: 5_000_000
+  violation_points: 35_000
 Metrics/ParameterList:
-  base_points: 10_000
-  violation_points: 50_000
+  base_points: 500_000
+  violation_points: 100_000
 Metrics/PerceivedComplexity:
-  base_points: 50_000
-  violation_points: 5000
+  base_points: 1_000_000
+  violation_points: 70_000

--- a/spec/cc/engine/rubocop_spec.rb
+++ b/spec/cc/engine/rubocop_spec.rb
@@ -323,7 +323,7 @@ module CC::Engine
       def includes_content_for?(output, cop_name)
         issue = issues(output).detect { |i| i["check_name"] =~ /#{cop_name}$/ }
 
-        issue["content"]["body"].present?
+        issue["content"] && issue["content"]["body"].present?
       end
 
       def issues(output)


### PR DESCRIPTION
Tune complexity points, following calculation function in [codeclimate-eslint](https://github.com/codeclimate/codeclimate-eslint/blob/master/lib/checks.js#L117), creating more parity with Ruby analysis in Code Climate classic.

cc @codeclimate/review @noahd1 