### PR TITLE
Update rubocop to 0.36.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ Style/PercentLiteralDelimiters:
     '%W': '[]'
 Style/StringLiterals:
   Enabled: false
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
   Enabled: false
 Style/DotPosition:
   EnforcedStyle: 'trailing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,6 @@ GEM
       tzinfo (~> 1.1)
     ansi (1.5.0)
     ast (2.2.0)
-    astrolabe (1.3.1)
-      parser (~> 2.2)
     builder (3.2.2)
     coderay (1.1.0)
     i18n (0.7.0)
@@ -25,8 +23,8 @@ GEM
       ruby-progressbar
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    parser (2.2.3.0)
-      ast (>= 1.1, < 3.0)
+    parser (2.3.0.1)
+      ast (~> 2.2)
     powerpack (0.1.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -34,19 +32,16 @@ GEM
       slop (~> 3.4)
     rainbow (2.0.0)
     rake (10.4.2)
-    rubocop (0.35.1)
-      astrolabe (~> 1.3)
-      parser (>= 2.2.3.0, < 3.0)
+    rubocop (0.36.0)
+      parser (>= 2.3.0.0, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
-      tins (<= 1.6.0)
     rubocop-rspec (1.3.0)
     ruby-progressbar (1.7.5)
     safe_yaml (1.0.4)
     slop (3.6.0)
     thread_safe (0.3.5)
-    tins (1.6.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
 
@@ -63,3 +58,6 @@ DEPENDENCIES
   rubocop
   rubocop-rspec
   safe_yaml
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
Hi. code climate team.
Some of your warnings are not proper in our project, since I use rubocop `0.36.0` and this version change some indenting rule.