### PR TITLE
Update rubocop-rspec to 1.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 0.3)
-    rubocop-rspec (1.3.1)
+    rubocop-rspec (1.4.0)
     ruby-progressbar (1.7.5)
     safe_yaml (1.0.4)
     slop (3.6.0)


### PR DESCRIPTION
There are some incompatibilites between the latest version of RuboCop
and rubocop-rspec which were fixed in this release.

See: https://github.com/nevir/rubocop-rspec/issues/62

@codeclimate/review