### PR TITLE
FileListResolver: handle non-existent files

### DIFF
--- a/lib/cc/engine/file_list_resolver.rb
+++ b/lib/cc/engine/file_list_resolver.rb
@@ -20,7 +20,13 @@ module CC
       private
 
       def absolute_include_paths
-        @include_paths.map { |path| Pathname.new(path).realpath.to_s }
+        @include_paths.map do |path|
+          begin
+            Pathname.new(path).realpath.to_s
+          rescue Errno::ENOENT
+            nil
+          end
+        end.compact
       end
 
       def rubocop_file_to_include?(file)

--- a/spec/cc/engine/file_list_resolver_spec.rb
+++ b/spec/cc/engine/file_list_resolver_spec.rb
@@ -1,0 +1,62 @@
+require "spec_helper"
+require "rubocop"
+require "cc/engine/file_list_resolver"
+
+module CC::Engine
+  describe FileListResolver do
+    include FilesystemHelpers
+
+    before { @code = Dir.mktmpdir }
+    let(:rubocop_config) { RuboCop::ConfigStore.new }
+
+    it "uses default include path" do
+      Dir.chdir(@code) do
+        create_source_file("a.rb", "def a; true; end")
+        create_source_file("not_ruby.txt", "some text")
+
+        resolver = FileListResolver.new(root: @code, engine_config: {}, config_store: rubocop_config)
+        expect(resolver.expanded_list).to eq [Pathname.new("a.rb").realpath.to_s]
+      end
+    end
+
+    it "finds ruby scripts without extensions" do
+      Dir.chdir(@code) do
+        create_source_file("a.rb", "def a; true; end")
+        create_source_file("bin/some_script", "#!/usr/bin/env ruby")
+
+        resolver = FileListResolver.new(root: @code, engine_config: {}, config_store: rubocop_config)
+        expect(resolver.expanded_list).to eq %w[a.rb bin/some_script].map { |fn| Pathname.new(fn).realpath.to_s }
+      end
+    end
+
+    it "respects engine config include_paths" do
+      Dir.chdir(@code) do
+        create_source_file("a.rb", "def a; true; end")
+        create_source_file("src/b.rb", "def a; true; end")
+
+        resolver = FileListResolver.new(root: @code, engine_config: { "include_paths" => %w[src/] }, config_store: rubocop_config)
+        expect(resolver.expanded_list).to eq [Pathname.new("src/b.rb").realpath.to_s]
+      end
+    end
+
+    it "respects rubocop excludes" do
+      Dir.chdir(@code) do
+        create_source_file("src/b.rb", "def a; true; end")
+        create_source_file("src/c.rb", "def a; true; end")
+        create_source_file(".rubocop.yml", "AllCops:\n  Exclude:\n    - src/c.rb")
+
+        resolver = FileListResolver.new(root: @code, engine_config: { "include_paths" => %w[src/] }, config_store: rubocop_config)
+        expect(resolver.expanded_list).to eq [Pathname.new("src/b.rb").realpath.to_s]
+      end
+    end
+
+    it "handles missing files" do
+      Dir.chdir(@code) do
+        create_source_file("src/b.rb", "def a; true; end")
+
+        resolver = FileListResolver.new(root: @code, engine_config: { "include_paths" => %w[src/ public/assets] }, config_store: rubocop_config)
+        expect(resolver.expanded_list).to eq [Pathname.new("src/b.rb").realpath.to_s]
+      end
+    end
+  end
+end

--- a/spec/cc/engine/rubocop_spec.rb
+++ b/spec/cc/engine/rubocop_spec.rb
@@ -4,6 +4,7 @@ require "tmpdir"
 
 module CC::Engine
   describe Rubocop do
+    include FilesystemHelpers
     before { @code = Dir.mktmpdir }
 
     describe "#run" do
@@ -331,12 +332,6 @@ module CC::Engine
 
       def issues(output)
         output.split("\0").map { |x| JSON.parse(x) }
-      end
-
-      def create_source_file(path, content)
-        abs_path = File.join(@code, path)
-        FileUtils.mkdir_p(File.dirname(abs_path))
-        File.write(abs_path, content)
       end
 
       def run_engine(config = nil)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,3 @@
 require "rspec"
+
+Dir.glob("spec/support/**/*.rb").each(&method(:load))

--- a/spec/support/filesystem_helpers.rb
+++ b/spec/support/filesystem_helpers.rb
@@ -1,0 +1,7 @@
+module FilesystemHelpers
+  def create_source_file(path, content)
+    abs_path = File.join(@code, path)
+    FileUtils.mkdir_p(File.dirname(abs_path))
+    File.write(abs_path, content)
+  end
+end


### PR DESCRIPTION
A couple crashes came up this morning as a result of non-existent files trying to be read by the file list resolver. This bug surfaced because of the changes to trying to make all paths absolute.

Took the opportunity to test this class more broadly, as well.

@codeclimate/review