### PR TITLE
Upgrade parser gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem "rubocop", "~> 0.37.2", require: false
 gem "rubocop-rspec", require: false
 gem "safe_yaml"
 gem "pry", require: false
+gem "parser", "~> 2.3.0.5"
 
 group :test do
   gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
     json (1.8.3)
     method_source (0.8.2)
     minitest (5.8.4)
-    parser (2.3.0.4)
+    parser (2.3.0.6)
       ast (~> 2.2)
     powerpack (0.1.1)
     pry (0.10.3)
@@ -56,6 +56,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
+  parser (~> 2.3.0.5)
   pry
   rake
   rspec


### PR DESCRIPTION
Parser has a bug with out of range characters that was fixed in
2.3.0.5. This fix sets the version requirement for parser to be
~> 2.3.0.5.

See: https://github.com/bbatsov/rubocop/issues/2833

@codeclimate/review