### PR TITLE
Explicitly check RuboCop excludes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,9 @@ Style/PercentLiteralDelimiters:
     '%W': '[]'
 Style/StringLiterals:
   Enabled: false
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
+  Enabled: false
+Style/TrailingCommaInArguments:
   Enabled: false
 Style/DotPosition:
   EnforcedStyle: 'trailing'

--- a/lib/cc/engine/file_list_resolver.rb
+++ b/lib/cc/engine/file_list_resolver.rb
@@ -19,6 +19,8 @@ module CC
 
       private
 
+      attr_reader :config_store
+
       def absolute_include_paths
         @include_paths.map do |path|
           begin
@@ -30,12 +32,12 @@ module CC
       end
 
       def rubocop_file_to_include?(file)
-        if file =~ /\.rb$/
-          true
-        else
-          root, basename = File.split(file)
-          @config_store.for(root).file_to_include?(basename)
-        end
+        root, basename = File.split(file)
+        store = config_store.for(root)
+
+        return false if store.file_to_exclude?(basename)
+
+        file =~ /\.rb$/ || store.file_to_include?(basename)
       end
 
       def rubocop_runner

--- a/spec/cc/engine/file_list_resolver_spec.rb
+++ b/spec/cc/engine/file_list_resolver_spec.rb
@@ -41,11 +41,12 @@ module CC::Engine
 
     it "respects rubocop excludes" do
       Dir.chdir(@code) do
+        create_source_file("Gemfile", "source 'https://rubygems.org'")
         create_source_file("src/b.rb", "def a; true; end")
         create_source_file("src/c.rb", "def a; true; end")
-        create_source_file(".rubocop.yml", "AllCops:\n  Exclude:\n    - src/c.rb")
+        create_source_file(".rubocop.yml", "AllCops:\n  Exclude:\n    - src/c.rb\n    - Gemfile\n")
 
-        resolver = FileListResolver.new(root: @code, engine_config: { "include_paths" => %w[src/] }, config_store: rubocop_config)
+        resolver = FileListResolver.new(root: @code, engine_config: { "include_paths" => %w[Gemfile src/] }, config_store: rubocop_config)
         expect(resolver.expanded_list).to eq [Pathname.new("src/b.rb").realpath.to_s]
       end
     end


### PR DESCRIPTION
RuboCop's ConfigStore will sometimes return conflicting answers for
file_to_exclude and file_to_include so check file_to_exclude explicitly
and skip the file in question if it returns true.

c/ @codeclimate/review