### PR TITLE
Add path-based fingerprint override for method/class offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,29 +1,17 @@
-Metrics/ModuleLength:
-  Exclude:
-    - 'spec/**/*'
-Style/ClassAndModuleChildren:
-  Exclude:
-    - 'spec/**/*'
-Metrics/LineLength:
-  Exclude:
-    - 'spec/**/*'
-Style/Documentation:
-  Enabled: false
+inherit_from: base_rubocop.yml
+
 Style/FileName:
   Exclude:
     - 'bin/codeclimate-rubocop'
-Style/PercentLiteralDelimiters:
-  PreferredDelimiters:
-    '%w': '[]'
-    '%W': '[]'
+
 Style/StringLiterals:
   Enabled: false
+
 Style/TrailingCommaInLiteral:
   Enabled: false
+
 Style/TrailingCommaInArguments:
   Enabled: false
-Style/DotPosition:
-  EnforcedStyle: 'trailing'
-  Enabled: true
+
 Style/MultilineOperationIndentation:
   Enabled: false

--- a/base_rubocop.yml
+++ b/base_rubocop.yml
@@ -1,0 +1,127 @@
+################################################################################
+# Metrics
+################################################################################
+
+Metrics/LineLength:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+################################################################################
+# Style
+################################################################################
+
+# Executables are conventionally named bin/foo-bar
+Style/FileName:
+  Exclude:
+  - bin/**/*
+
+# We don't (currently) document our code
+Style/Documentation:
+  Enabled: false
+
+# Always use double-quotes to keep things simple
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+
+# Use a trailing comma to keep diffs clean when elements are inserted or removed
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
+
+# We avoid GuardClause because it can result in "suprise return"
+Style/GuardClause:
+  Enabled: false
+
+# We avoid IfUnlessModifier because it can result in "suprise if"
+Style/IfUnlessModifier:
+  Enabled: false
+
+# We don't care about the fail/raise distinction
+Style/SignalException:
+  EnforcedStyle: only_raise
+
+Style/DotPosition:
+  EnforcedStyle: trailing
+
+# Common globals we allow
+Style/GlobalVars:
+  AllowedVariables:
+  - "$statsd"
+  - "$mongo"
+  - "$rollout"
+
+# Using english names requires loading an extra module, which is annoying, so
+# we prefer the perl names for consistency.
+Style/SpecialGlobalVars:
+  EnforcedStyle: use_perl_names
+
+# We have common cases where has_ and have_ make sense
+Style/PredicateName:
+  Enabled: true
+  NamePrefixBlacklist:
+  - is_
+
+# We use %w[ ], not %w( ) because the former looks like an array
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    "%w": []
+    "%W": []
+
+# Allow "trivial" accessors when defined as a predicate? method
+Style/TrivialAccessors:
+  AllowPredicates: true
+
+Style/Next:
+  Enabled: false
+
+# We think it's OK to use the "extend self" module pattern
+Style/ModuleFunction:
+  Enabled: false
+
+# Disallow extra spacing for token alignment
+Style/ExtraSpacing:
+  AllowForAlignment: false
+
+################################################################################
+# Performance
+################################################################################
+
+Performance/RedundantMerge:
+  Enabled: false
+
+################################################################################
+# Rails - disable things because we're primarily non-rails
+################################################################################
+
+Rails/Delegate:
+  Enabled: false
+
+Rails/TimeZone:
+  Enabled: false
+
+################################################################################
+# Specs - be more lenient on length checks and block styles
+################################################################################
+
+Metrics/ModuleLength:
+  Exclude:
+  - spec/**/*
+
+Metrics/MethodLength:
+  Exclude:
+  - spec/**/*
+
+Style/ClassAndModuleChildren:
+  Exclude:
+  - spec/**/*
+
+Style/BlockDelimiters:
+  Exclude:
+  - spec/**/*

--- a/bin/codeclimate-rubocop
+++ b/bin/codeclimate-rubocop
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-$LOAD_PATH.unshift(
+$:.unshift(
   File.expand_path(File.join(File.dirname(__FILE__), "../lib"))
 )
 

--- a/lib/cc/engine/fingerprint.rb
+++ b/lib/cc/engine/fingerprint.rb
@@ -1,0 +1,40 @@
+require "digest/md5"
+
+module CC
+  module Engine
+    class Fingerprint
+      OVERRIDE_COP_NAMES = %w[
+        Metrics/AbcSize
+        Metrics/ClassLength
+        Metrics/CyclomaticComplexity
+        Metrics/MethodLength
+        Metrics/ModuleLength
+        Metrics/PerceivedComplexity
+      ].freeze
+
+      def initialize(path, cop_name, message)
+        @path = path
+        @cop_name = cop_name
+        @message = message
+      end
+
+      def compute
+        if OVERRIDE_COP_NAMES.include?(cop_name)
+          md5 = Digest::MD5.new
+          md5 << path
+          md5 << cop_name
+          md5 << stripped_message
+          md5.hexdigest
+        end
+      end
+
+      private
+
+      attr_reader :path, :cop_name, :message
+
+      def stripped_message
+        message.gsub(/ \[.+\]$/, "")
+      end
+    end
+  end
+end

--- a/lib/cc/engine/issue.rb
+++ b/lib/cc/engine/issue.rb
@@ -1,4 +1,5 @@
-require 'safe_yaml'
+require "safe_yaml"
+
 SafeYAML::OPTIONS[:default_mode] = :safe
 
 module CC
@@ -20,7 +21,7 @@ module CC
       def to_json
         hash = {
           type: "Issue",
-          check_name: "Rubocop/#{cop_name}",
+          check_name: check_name,
           description: message,
           categories: [category],
           remediation_points: remediation_points,
@@ -30,7 +31,16 @@ module CC
           },
         }
         hash[:content] = { body: content_body } if content_body.present?
+
+        if (fingerprint = Fingerprint.new(path, cop_name, message).compute)
+          hash[:fingerprint] = fingerprint
+        end
+
         hash.to_json
+      end
+
+      def check_name
+        "Rubocop/#{cop_name}"
       end
 
       def remediation_points

--- a/lib/cc/engine/rubocop.rb
+++ b/lib/cc/engine/rubocop.rb
@@ -10,6 +10,7 @@ require "cc/engine/source_file"
 require "cc/engine/category_parser"
 require "cc/engine/file_list_resolver"
 require "cc/engine/issue"
+require "cc/engine/fingerprint"
 require "active_support"
 require "active_support/core_ext"
 

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -8,7 +8,7 @@ namespace :docs do
     %x{git clone https://github.com/bbatsov/rubocop.git rubocop-git}
     %x{cd rubocop-git && git checkout tags/v#{RuboCop::Version.version}}
 
-    files = Dir.glob("./rubocop-git/lib/rubocop/cop/{#{COP_FOLDERS.join(',')}}/**.rb")
+    files = Dir.glob("./rubocop-git/lib/rubocop/cop/{#{COP_FOLDERS.join(",")}}/**.rb")
 
     documentation = files.each_with_object({}) do |file, hash|
       content = File.read(file)


### PR DESCRIPTION
This PR implements override fingerprints for method and class-based offenses, incorporating the path, check name, and offense message.

@codeclimate/review :mag_right: