### PR TITLE
Update to rubocop 0.39.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem "activesupport", require: false
-gem "rubocop", "~> 0.37.2", require: false
+gem "rubocop", "~> 0.39.0", require: false
 gem "rubocop-rspec", require: false
 gem "safe_yaml"
 gem "pry", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,19 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.5.1)
+    activesupport (5.0.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    ast (2.2.0)
-    coderay (1.1.0)
+    ast (2.3.0)
+    coderay (1.1.1)
+    concurrent-ruby (1.0.2)
     diff-lcs (1.2.5)
     i18n (0.7.0)
-    json (1.8.3)
     method_source (0.8.2)
-    minitest (5.8.4)
-    parser (2.3.0.6)
+    minitest (5.9.0)
+    parser (2.3.0.7)
       ast (~> 2.2)
     powerpack (0.1.1)
     pry (0.10.3)
@@ -22,34 +21,35 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rainbow (2.1.0)
-    rake (10.5.0)
-    rspec (3.3.0)
-      rspec-core (~> 3.3.0)
-      rspec-expectations (~> 3.3.0)
-      rspec-mocks (~> 3.3.0)
-    rspec-core (3.3.1)
-      rspec-support (~> 3.3.0)
-    rspec-expectations (3.3.0)
+    rake (11.2.2)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.0)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-mocks (3.3.1)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-support (3.3.0)
-    rubocop (0.37.2)
-      parser (>= 2.3.0.4, < 3.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    rubocop (0.39.0)
+      parser (>= 2.3.0.7, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 0.3)
-    rubocop-rspec (1.4.0)
-    ruby-progressbar (1.7.5)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    rubocop-rspec (1.4.1)
+      rubocop (= 0.39.0)
+    ruby-progressbar (1.8.1)
     safe_yaml (1.0.4)
     slop (3.6.0)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    unicode-display_width (0.3.1)
+    unicode-display_width (1.1.0)
 
 PLATFORMS
   ruby
@@ -60,9 +60,9 @@ DEPENDENCIES
   pry
   rake
   rspec
-  rubocop (~> 0.37.2)
+  rubocop (~> 0.39.0)
   rubocop-rspec
   safe_yaml
 
 BUNDLED WITH
-   1.11.2
+   1.12.5


### PR DESCRIPTION
See changelog:
https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md

And diff:
https://github.com/bbatsov/rubocop/compare/v0.37.2...v0.39.0