### PR TITLE
Use Config#target_ruby_version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,11 @@
 source 'https://rubygems.org'
 
 gem "activesupport", require: false
-gem "rubocop", "~> 0.37.2", require: false
+gem "rubocop", "~> 0.41.2", require: false
 gem "rubocop-rspec", require: false
 gem "safe_yaml"
 gem "pry", require: false
-gem "parser", "~> 2.3.0.5"
+gem "parser", "~> 2.3.1.1"
 
 group :test do
   gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,14 +7,14 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    ast (2.2.0)
+    ast (2.3.0)
     coderay (1.1.0)
     diff-lcs (1.2.5)
     i18n (0.7.0)
     json (1.8.3)
     method_source (0.8.2)
     minitest (5.8.4)
-    parser (2.3.0.6)
+    parser (2.3.1.2)
       ast (~> 2.2)
     powerpack (0.1.1)
     pry (0.10.3)
@@ -36,31 +36,31 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
-    rubocop (0.37.2)
-      parser (>= 2.3.0.4, < 3.0)
+    rubocop (0.41.2)
+      parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 0.3)
+      unicode-display_width (~> 1.0, >= 1.0.1)
     rubocop-rspec (1.4.0)
-    ruby-progressbar (1.7.5)
+    ruby-progressbar (1.8.1)
     safe_yaml (1.0.4)
     slop (3.6.0)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    unicode-display_width (0.3.1)
+    unicode-display_width (1.1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activesupport
-  parser (~> 2.3.0.5)
+  parser (~> 2.3.1.1)
   pry
   rake
   rspec
-  rubocop (~> 0.37.2)
+  rubocop (~> 0.41.2)
   rubocop-rspec
   safe_yaml
 

--- a/lib/cc/engine/source_file.rb
+++ b/lib/cc/engine/source_file.rb
@@ -26,7 +26,7 @@ module CC
       end
 
       def target_ruby_version
-        config_store["AllCops"] && config_store["AllCops"]["TargetRubyVersion"]
+        config_store.target_ruby_version
       end
 
       def rubocop_team


### PR DESCRIPTION
This is the logic that we're replacing, plus smart reading of .ruby-version if
present and not overridden by the AllCops rule.

Required updating rubocop to [0.41.2](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0412-2016-07-07)

/cc @codeclimate/review can I get a second set of eyes down the rubocop
CHANGELOG to see if I missed any compatibility concerns?

TODO: update docs.codeclimate.com