### PR TITLE
Correctly strip detailed message in fingerprint

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,3 +4,5 @@ engines:
 ratings:
   paths:
   - "**.rb"
+exclude_paths:
+- spec/

--- a/lib/cc/engine/fingerprint.rb
+++ b/lib/cc/engine/fingerprint.rb
@@ -12,6 +12,9 @@ module CC
         Metrics/PerceivedComplexity
       ].freeze
 
+      URL_REGEX = / \(https?\:.+\)/
+      LINES_REGEX = / \[.+\]$/
+
       def initialize(path, cop_name, message)
         @path = path
         @cop_name = cop_name
@@ -33,7 +36,7 @@ module CC
       attr_reader :path, :cop_name, :message
 
       def stripped_message
-        message.gsub(/ \[.+\]$/, "")
+        message.gsub(URL_REGEX, "").strip.gsub(LINES_REGEX, "")
       end
     end
   end

--- a/spec/cc/engine/fingerprint_spec.rb
+++ b/spec/cc/engine/fingerprint_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+require "cc/engine/fingerprint"
+
+module CC::Engine
+  describe Fingerprint do
+    describe "#compute" do
+      it "returns a fingerprint for method/class offenses" do
+        cop_name = "Metrics/ModuleLength"
+        path = "foo/bar.rb"
+        message = "foo"
+
+        computed = Fingerprint.new(path, cop_name, message).compute
+
+        expect(computed).to eq "53a5f182884e58dcb16d24fca37e10bc"
+      end
+
+      it "returns nil for non method/class offenses" do
+        cop_name = "Style/Foo"
+        path = "foo/bar.rb"
+        message = "foo"
+
+        computed = Fingerprint.new(path, cop_name, message).compute
+
+        expect(computed).not_to be
+      end
+
+      it "computes same fingerprint regardles of message url detail" do
+        cop_name = "Metrics/ModuleLength"
+        path = "foo/bar.rb"
+
+        plain = "Metrics/MethodLength: Method has too many lines. [18/10]"
+        verbose = "Metrics/MethodLength: Method has too many lines. [18/10]  (https://github.com/bbatsov/ruby-style-guide#short-methods)"
+
+        verbose_print = Fingerprint.new(path, cop_name, verbose).compute
+        plain_print = Fingerprint.new(path, cop_name, plain).compute
+
+        expect(verbose_print).to eq plain_print
+      end
+
+      it "computes same fingerprint regardles of line number detail" do
+        old_count = "Metrics/MethodLength: Method has too many lines. [20/10]"
+        improved_count = "Metrics/MethodLength: Method has too many lines. [18/10]"
+
+        cop_name = "Metrics/ModuleLength"
+        path = "foo/bar.rb"
+
+        old_fingerprint = Fingerprint.new(path, cop_name, old_count).compute
+        improved_fingerprint = Fingerprint.new(path, cop_name, improved_count).compute
+
+        expect(old_fingerprint).to eq improved_fingerprint
+      end
+    end
+  end
+end


### PR DESCRIPTION
A user may elect more detailed messaging in RuboCop output by configuring:

    AllCops:
      DisplayCopNames: true
      DisplayStyleGuide: true
      ExtraDetails: true

which adds a url to issue messages, part of the fingerprint compute.

To correctly compute fingerprints in this case, we need an extra strip step.

@codeclimate/review 

cc @almostwhitehat with a thanks for finding this bug.