### PR TITLE
Add RuboCop Migrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem "activesupport", require: false
 gem "rubocop", "~> 0.41.2", require: false
 gem "rubocop-rspec", require: false
+gem "rubocop-migrations", require: false
 gem "safe_yaml"
 gem "pry", require: false
 gem "parser", "~> 2.3.1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
+    rubocop-migrations (0.1.1)
+      rubocop (~> 0.41.0)
     rubocop-rspec (1.5.0)
       rubocop (>= 0.40.0)
     ruby-progressbar (1.8.1)
@@ -62,8 +64,9 @@ DEPENDENCIES
   rake
   rspec
   rubocop (~> 0.41.2)
+  rubocop-migrations
   rubocop-rspec
   safe_yaml
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/lib/cc/engine/category_parser.rb
+++ b/lib/cc/engine/category_parser.rb
@@ -25,6 +25,7 @@ module CC
         "Rails/TimeZone" => "Style",
         "Rails/Validation" => "Style",
         "Style" => "Style",
+        "Migrations/RemoveIndex" => "Performance",
       }.freeze
 
       attr_reader :cop_name


### PR DESCRIPTION
Hi!

We want to start using a new rubocop extension we developed (https://rubygems.org/gems/rubocop-migrations). It is a simple gem that disallows index removal from rails migrations (so you don't accidentally remove an index that is being used).

Given that we use codeclimate, it would be nice to be able to use that there.