### PR TITLE
Add GEM_PATH env var to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,6 @@ USER app
 
 VOLUME /code
 WORKDIR /code
+ENV GEM_PATH /code/vendor/bundle/ruby/2.2.0
 
 CMD ["/usr/src/app/bin/codeclimate-rubocop"]


### PR DESCRIPTION
...to use code's bundle, which may include rubocop extensions.