### PR TITLE
Override default fingerprinting for Metrics/BlockLength

### DIFF
--- a/lib/cc/engine/fingerprint.rb
+++ b/lib/cc/engine/fingerprint.rb
@@ -5,6 +5,7 @@ module CC
     class Fingerprint
       OVERRIDE_COP_NAMES = %w[
         Metrics/AbcSize
+        Metrics/BlockLength
         Metrics/ClassLength
         Metrics/CyclomaticComplexity
         Metrics/MethodLength


### PR DESCRIPTION
Noticed in a recent build that this cop is showing up as fixed/new
rather than changed. It was added in RuboCop v0.44, which we just
upgraded to.

@codeclimate/review 