### PR TITLE
Clean up Makefile, release to docker hub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,17 @@
-.PHONY: image test
+.PHONY: image test release
 
-IMAGE_NAME ?= codeclimate/codeclimate-rubocop
+RELEASE_REGISTRY ?= codeclimate
+RELEASE_TAG ?= latest
 
 image:
-	docker build --rm -t $(IMAGE_NAME) .
+	docker build --tag codeclimate/codeclimate-rubocop .
 
-test: image
-	docker run --rm $(IMAGE_NAME) sh -c "cd /usr/src/app && bundle exec rake"
+test:
+	docker run --workdir /usr/src/app \
+	  codeclimate/codeclimate-rubocop bundle exec rake
+
+release:
+	test -n "$(RELEASE_TAG)"
+	docker tag codeclimate/codeclimate-rubocop \
+	  $(RELEASE_REGISTRY)/codeclimate-rubocop:$(RELEASE_TAG)
+	docker push $(RELEASE_REGISTRY)/codeclimate-rubocop:$(RELEASE_TAG)

--- a/circle.yml
+++ b/circle.yml
@@ -1,28 +1,27 @@
 machine:
   services:
     - docker
-  environment:
-    CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-    PRIVATE_REGISTRY: us.gcr.io/code_climate
 
 dependencies:
   override:
-    - echo "no-op"
+    - make image
 
 test:
   override:
-    - IMAGE_NAME="$PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM" make test
+    - make test
 
 deployment:
   registry:
     branch: master
     owner: codeclimate
     commands:
-      - echo $GCLOUD_JSON_KEY_BASE64 | sed 's/ //g' | base64 -d > /tmp/gcloud_key.json
-      - curl https://sdk.cloud.google.com | bash
-      - gcloud auth activate-service-account --key-file /tmp/gcloud_key.json
-      - gcloud docker -a
-      - docker push $PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM
+      - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+      - make release RELEASE_TAG=latest
+      - make release RELEASE_TAG=b$CIRCLE_BUILD_NUM
+
+      # Temporarily push to GCR
+      - docker login -u _json_key -p "$(echo $GCLOUD_JSON_KEY_BASE64 | sed 's/ //g' | base64 -d)" us.gcr.io
+      - make release RELEASE_REGISTRY=us.gcr.io/code_climate RELEASE_TAG=b$CIRCLE_BUILD_NUM
 
 notify:
   webhooks:


### PR DESCRIPTION
- Remove IMAGE_NAME

  This is an implementation detail of the Makefile. With the new release
  task, the registry and tag can be injected, but the engine name is
  fixed (to prevent errors) and the image name as built (and used for
  tests) is private (to avoid confusion).

- Add a test target

  This is tailored for CI usage more than local, since that's by far the
  most frequent use-case.

- Add a release target

  By injecting the registry and tag this is re-usable for GCR. Even
  though that's temporary, the flexibility is still valuable going
  forward.

  The caller is expected to have already logged in at the location
  they're releasing two. This helps keep the Makefile interface simple.

- Release to DockerHub

  This is where engine images will reside long-term. We continue to
  release to GCR additionally to not break production during the
  transition.

/cc @codeclimate/review

Now's the time to bikeshed! Once everyone's good on the general pattern of
Makefile+circle.yml here, I'm going to implement it across all the engines.