### PR TITLE
Bump RuboCop to 0.47.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /usr/src/app
 COPY Gemfile /usr/src/app/
 COPY Gemfile.lock /usr/src/app/
 
-RUN gem install bundler && \
+RUN gem update --system && \
+    gem install bundler && \
     bundle install -j 4 && \
     rm -fr /usr/share/ri
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gem "activesupport", require: false
 gem "parser", "~> 2.3.3.1"
 gem "pry", require: false
-gem "rubocop", "~> 0.45", require: false
+gem "rubocop", "~> 0.47.1", require: false
 gem "rubocop-migrations", require: false
 gem "rubocop-rspec", require: false
 gem "safe_yaml"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rainbow (2.1.0)
+    rainbow (2.2.1)
     rake (12.0.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -35,8 +35,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.46.0)
-      parser (>= 2.3.1.1, < 3.0)
+    rubocop (0.47.1)
+      parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
@@ -51,7 +51,7 @@ GEM
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    unicode-display_width (1.1.2)
+    unicode-display_width (1.1.3)
 
 PLATFORMS
   ruby
@@ -62,10 +62,10 @@ DEPENDENCIES
   pry
   rake
   rspec
-  rubocop (~> 0.45)
+  rubocop (~> 0.47.1)
   rubocop-migrations
   rubocop-rspec
   safe_yaml
 
 BUNDLED WITH
-   1.13.6
+   1.14.4

--- a/config/contents/lint/ambiguous_operator.md
+++ b/config/contents/lint/ambiguous_operator.md
@@ -2,11 +2,16 @@ This cop checks for ambiguous operators in the first argument of a
 method invocation without parentheses.
 
 ### Example:
-    array = [1, 2, 3]
+
+    # bad
 
     # The `*` is interpreted as a splat operator but it could possibly be
-    # a `*` method invocation (i.e. `do_something.*(array)`).
-    do_something *array
+    # a `*` method invocation (i.e. `do_something.*(some_array)`).
+    do_something *some_array
+
+### Example:
+
+    # good
 
     # With parentheses, there's no ambiguity.
-    do_something(*array)
+    do_something(*some_array)

--- a/config/contents/lint/ambiguous_regexp_literal.md
+++ b/config/contents/lint/ambiguous_regexp_literal.md
@@ -2,10 +2,17 @@ This cop checks for ambiguous regexp literals in the first argument of
 a method invocation without parentheses.
 
 ### Example:
+
+    # bad
+
     # This is interpreted as a method invocation with a regexp literal,
     # but it could possibly be `/` method invocations.
     # (i.e. `do_something./(pattern)./(i)`)
     do_something /pattern/i
+
+### Example:
+
+    # good
 
     # With parentheses, there's no ambiguity.
     do_something(/pattern/i)

--- a/config/contents/lint/assignment_in_condition.md
+++ b/config/contents/lint/assignment_in_condition.md
@@ -1,0 +1,18 @@
+This cop checks for assignments in the conditions of
+if/while/until.
+
+### Example:
+
+    # bad
+
+    if some_var = true
+      do_something
+    end
+
+### Example:
+
+    # good
+
+    if some_var == true
+      do_something
+    end

--- a/config/contents/lint/block_alignment.md
+++ b/config/contents/lint/block_alignment.md
@@ -1,8 +1,8 @@
 This cop checks whether the end keywords are aligned properly for do
 end blocks.
 
-Three modes are supported through the `AlignWith` configuration
-parameter:
+Three modes are supported through the `EnforcedStyleAlignWith`
+configuration parameter:
 
 `start_of_block` : the `end` shall be aligned with the
 start of the line where the `do` appeared.
@@ -15,18 +15,40 @@ location. The autofixer will default to `start_of_line`.
 
 ### Example:
 
-    # either
+    # bad
+
+    foo.bar
+       .each do
+         baz
+           end
+
+### Example:
+
+    # EnforcedStyleAlignWith: either (default)
+
+    # good
+
     variable = lambda do |i|
       i
     end
 
-    # start_of_block
+### Example:
+
+    # EnforcedStyleAlignWith: start_of_block
+
+    # good
+
     foo.bar
       .each do
          baz
        end
 
-    # start_of_line
+### Example:
+
+    # EnforcedStyleAlignWith: start_of_line
+
+    # good
+
     foo.bar
       .each do
          baz

--- a/config/contents/lint/circular_argument_reference.md
+++ b/config/contents/lint/circular_argument_reference.md
@@ -4,27 +4,41 @@ arguments and optional ordinal arguments.
 This cop mirrors a warning produced by MRI since 2.2.
 
 ### Example:
+
     # bad
+
     def bake(pie: pie)
       pie.heat_up
     end
 
+### Example:
+
     # good
+
     def bake(pie:)
       pie.refrigerate
     end
 
+### Example:
+
     # good
+
     def bake(pie: self.pie)
       pie.feed_to(user)
     end
 
+### Example:
+
     # bad
+
     def cook(dry_ingredients = dry_ingredients)
       dry_ingredients.reduce(&:+)
     end
 
+### Example:
+
     # good
+
     def cook(dry_ingredients = self.dry_ingredients)
       dry_ingredients.combine
     end

--- a/config/contents/lint/condition_position.md
+++ b/config/contents/lint/condition_position.md
@@ -3,7 +3,17 @@ if/while/until.
 
 ### Example:
 
+    # bad
+
     if
       some_condition
+      do_something
+    end
+
+### Example:
+
+    # good
+
+    if some_condition
       do_something
     end

--- a/config/contents/lint/debugger.md
+++ b/config/contents/lint/debugger.md
@@ -1,0 +1,29 @@
+This cop checks for calls to debugger or pry.
+
+### Example:
+
+    # bad (ok during development)
+
+    # using pry
+    def some_method
+      binding.pry
+      do_something
+    end
+
+### Example:
+
+    # bad (ok during development)
+
+    # using byebug
+    def some_method
+      byebug
+      do_something
+    end
+
+### Example:
+
+    # good
+
+    def some_method
+      do_something
+    end

--- a/config/contents/lint/def_end_alignment.md
+++ b/config/contents/lint/def_end_alignment.md
@@ -1,7 +1,7 @@
 This cop checks whether the end keywords of method definitions are
 aligned properly.
 
-Two modes are supported through the AlignWith configuration
+Two modes are supported through the EnforcedStyleAlignWith configuration
 parameter. If it's set to `start_of_line` (which is the default), the
 `end` shall be aligned with the start of the line where the `def`
 keyword is. If it's set to `def`, the `end` shall be aligned with the
@@ -9,5 +9,25 @@ keyword is. If it's set to `def`, the `end` shall be aligned with the
 
 ### Example:
 
+    # bad
+
+    private def foo
+                end
+
+### Example:
+
+    # EnforcedStyleAlignWith: start_of_line (default)
+
+    # good
+
     private def foo
     end
+
+### Example:
+
+    # EnforcedStyleAlignWith: def
+
+    # good
+
+    private def foo
+            end

--- a/config/contents/lint/deprecated_class_methods.md
+++ b/config/contents/lint/deprecated_class_methods.md
@@ -1,0 +1,13 @@
+This cop checks for uses of the deprecated class method usages.
+
+### Example:
+
+    # bad
+
+    File.exists?(some_path)
+
+### Example:
+
+    # good
+
+    File.exist?(some_path)

--- a/config/contents/lint/duplicate_case_condition.md
+++ b/config/contents/lint/duplicate_case_condition.md
@@ -3,10 +3,22 @@ used in case 'when' expressions.
 
 ### Example:
 
-     # bad
-     case x
-     when 'first'
-       do_something
-     when 'first'
-       do_something_else
-     end
+    # bad
+
+    case x
+    when 'first'
+      do_something
+    when 'first'
+      do_something_else
+    end
+
+### Example:
+
+    # good
+
+    case x
+    when 'first
+      do_something
+    when 'second'
+      do_something_else
+    end

--- a/config/contents/lint/duplicate_methods.md
+++ b/config/contents/lint/duplicate_methods.md
@@ -2,11 +2,25 @@ This cop checks for duplicated instance (or singleton) method
 definitions.
 
 ### Example:
+
     # bad
+
     def duplicated
       1
     end
 
     def duplicated
+      2
+    end
+
+### Example:
+
+    # good
+
+    def duplicated
+      1
+    end
+
+    def other_duplicated
       2
     end

--- a/config/contents/lint/duplicated_key.md
+++ b/config/contents/lint/duplicated_key.md
@@ -3,4 +3,13 @@ This cop checks for duplicated keys in hash literals.
 This cop mirrors a warning in Ruby 2.2.
 
 ### Example:
+
+    # bad
+
     hash = { food: 'apple', food: 'orange' }
+
+### Example:
+
+    # good
+
+    hash = { food: 'apple', other_food: 'orange' }

--- a/config/contents/lint/each_with_object_argument.md
+++ b/config/contents/lint/each_with_object_argument.md
@@ -6,4 +6,13 @@ It's definitely a bug.
 
 ### Example:
 
+    # bad
+
     sum = numbers.each_with_object(0) { |e, a| a += e }
+
+### Example:
+
+    # good
+
+    num = 0
+    sum = numbers.each_with_object(num) { |e, a| a += e }

--- a/config/contents/lint/else_layout.md
+++ b/config/contents/lint/else_layout.md
@@ -4,8 +4,21 @@ which is usually a mistake.
 
 ### Example:
 
+    # bad
+
     if something
       ...
     else do_this
+      do_that
+    end
+
+### Example:
+
+    # good
+
+    if something
+      ...
+    else
+      do_this
       do_that
     end

--- a/config/contents/lint/empty_ensure.md
+++ b/config/contents/lint/empty_ensure.md
@@ -1,0 +1,39 @@
+This cop checks for empty `ensure` blocks
+
+### Example:
+
+    # bad
+
+    def some_method
+      do_something
+    ensure
+    end
+
+### Example:
+
+    # bad
+
+    begin
+      do_something
+    ensure
+    end
+
+### Example:
+
+    # good
+
+    def some_method
+      do_something
+    ensure
+      do_something_else
+    end
+
+### Example:
+
+    # good
+
+    begin
+      do_something
+    ensure
+      do_something_else
+    end

--- a/config/contents/lint/empty_expression.md
+++ b/config/contents/lint/empty_expression.md
@@ -3,7 +3,17 @@ This cop checks for the presence of empty expressions.
 ### Example:
 
     # bad
+
     foo = ()
     if ()
+      bar
+    end
+
+### Example:
+
+    # good
+
+    foo = (some_expression)
+    if (some_expression)
       bar
     end

--- a/config/contents/lint/empty_interpolation.md
+++ b/config/contents/lint/empty_interpolation.md
@@ -2,4 +2,12 @@ This cop checks for empty interpolation.
 
 ### Example:
 
+    # bad
+
     "result is #{}"
+
+### Example:
+
+    # good
+
+    "result is #{some_result}"

--- a/config/contents/lint/empty_when.md
+++ b/config/contents/lint/empty_when.md
@@ -3,7 +3,17 @@ This cop checks for the presence of `when` branches without a body.
 ### Example:
 
     # bad
+
     case foo
     when bar then 1
     when baz then # nothing
+    end
+
+### Example:
+
+    # good
+
+    case foo
+    when bar then 1
+    when baz then 2
     end

--- a/config/contents/lint/end_alignment.md
+++ b/config/contents/lint/end_alignment.md
@@ -1,7 +1,7 @@
 This cop checks whether the end keywords are aligned properly.
 
-Three modes are supported through the `AlignWith` configuration
-parameter:
+Three modes are supported through the `EnforcedStyleAlignWith`
+configuration parameter:
 
 If it's set to `keyword` (which is the default), the `end`
 shall be aligned with the start of the keyword (if, class, etc.).
@@ -13,15 +13,35 @@ If it's set to `start_of_line`, the `end` shall be aligned with the
 start of the line where the matching keyword appears.
 
 ### Example:
+
+    # bad
+
+    variable = if true
+        end
+
+### Example:
+
+    # EnforcedStyleAlignWith: keyword (default)
+
     # good
-    # keyword style
+
     variable = if true
                end
 
-    # variable style
+### Example:
+
+    # EnforcedStyleAlignWith: variable
+
+    # good
+
     variable = if true
     end
 
-    # start_of_line style
+### Example:
+
+    # EnforcedStyleAlignWith: start_of_line
+
+    # good
+
     puts(if true
     end)

--- a/config/contents/lint/end_in_method.md
+++ b/config/contents/lint/end_in_method.md
@@ -1,0 +1,24 @@
+This cop checks for END blocks in method definitions.
+
+### Example:
+
+    # bad
+
+    def some_method
+      END { do_something }
+    end
+
+### Example:
+
+    # good
+
+    def some_method
+      at_exit { do_something }
+    end
+
+### Example:
+
+    # good
+
+    # outside defs
+    END { do_something }

--- a/config/contents/lint/ensure_return.md
+++ b/config/contents/lint/ensure_return.md
@@ -1,0 +1,22 @@
+This cop checks for *return* from an *ensure* block.
+
+### Example:
+
+    # bad
+
+    begin
+      do_something
+    ensure
+      do_something_else
+      return
+    end
+
+### Example:
+
+    # good
+
+    begin
+      do_something
+    ensure
+      do_something_else
+    end

--- a/config/contents/lint/float_out_of_range.md
+++ b/config/contents/lint/float_out_of_range.md
@@ -3,8 +3,13 @@ really really really really really big. Too big. No-one needs Floats
 that big. If you need a float that big, something is wrong with you.
 
 ### Example:
+
     # bad
+
     float = 3.0e400
 
+### Example:
+
     # good
+
     float = 42.9

--- a/config/contents/lint/format_parameter_mismatch.md
+++ b/config/contents/lint/format_parameter_mismatch.md
@@ -4,4 +4,12 @@ passed as arguments.
 
 ### Example:
 
+    # bad
+
     format('A value: %s and another: %i', a_value)
+
+### Example:
+
+    # good
+
+    format('A value: %s and another: %i', a_value, another)

--- a/config/contents/lint/handle_exceptions.md
+++ b/config/contents/lint/handle_exceptions.md
@@ -1,0 +1,41 @@
+This cop checks for *rescue* blocks with no body.
+
+### Example:
+
+    # bad
+
+    def some_method
+      do_something
+    rescue
+      # do nothing
+    end
+
+### Example:
+
+    # bad
+
+    begin
+      do_something
+    rescue
+      # do nothing
+    end
+
+### Example:
+
+    # good
+
+    def some_method
+      do_something
+    rescue
+      handle_exception
+    end
+
+### Example:
+
+    # good
+
+    begin
+      do_something
+    rescue
+      handle_exception
+    end

--- a/config/contents/lint/implicit_string_concatenation.md
+++ b/config/contents/lint/implicit_string_concatenation.md
@@ -2,10 +2,15 @@ This cop checks for implicit string concatenation of string literals
 which are on the same line.
 
 ### Example:
+
     # bad
+
     array = ['Item 1' 'Item 2']
 
+### Example:
+
     # good
+
     array = ['Item 1Item 2']
     array = ['Item 1' + 'Item 2']
     array = [

--- a/config/contents/lint/ineffective_access_modifier.md
+++ b/config/contents/lint/ineffective_access_modifier.md
@@ -4,7 +4,9 @@ singleton methods private/protected. `private_class_method` can be
 used for that.
 
 ### Example:
+
     # bad
+
     class C
       private
 
@@ -13,7 +15,10 @@ used for that.
       end
     end
 
+### Example:
+
     # good
+
     class C
       def self.method
         puts 'hi'
@@ -21,6 +26,10 @@ used for that.
 
       private_class_method :method
     end
+
+### Example:
+
+    # good
 
     class C
       class << self

--- a/config/contents/lint/invalid_character_literal.md
+++ b/config/contents/lint/invalid_character_literal.md
@@ -11,4 +11,7 @@ warning without syntax errors.
          ^
 
 ### Example:
+
+    # bad
+
     p(? )

--- a/config/contents/lint/literal_in_condition.md
+++ b/config/contents/lint/literal_in_condition.md
@@ -4,10 +4,24 @@ if/while/until.
 
 ### Example:
 
+    # bad
+
     if 20
       do_something
     end
 
+### Example:
+
+    # bad
+
     if some_var && true
+      do_something
+    end
+
+### Example:
+
+    # good
+
+    if some_var && some_condition
       do_something
     end

--- a/config/contents/lint/literal_in_interpolation.md
+++ b/config/contents/lint/literal_in_interpolation.md
@@ -2,4 +2,12 @@ This cop checks for interpolated literals.
 
 ### Example:
 
+    # bad
+
     "result is #{10}"
+
+### Example:
+
+    # good
+
+    "result is 10"

--- a/config/contents/lint/loop.md
+++ b/config/contents/lint/loop.md
@@ -1,0 +1,37 @@
+This cop checks for uses of *begin...end while/until something*.
+
+### Example:
+
+    # bad
+
+    # using while
+    begin
+      do_something
+    end while some_condition
+
+### Example:
+
+    # bad
+
+    # using until
+    begin
+      do_something
+    end until some_condition
+
+### Example:
+
+    # good
+
+    # using while
+    while some_condition
+      do_something
+    end
+
+### Example:
+
+    # good
+
+    # using until
+    until some_condition
+      do_something
+    end

--- a/config/contents/lint/multiple_compare.md
+++ b/config/contents/lint/multiple_compare.md
@@ -1,0 +1,18 @@
+In math and Python, we can use `x < y < z` style comparison to compare
+multiple value. However, we can't use the comparison in Ruby. However,
+the comparison is not syntax error. This cop checks the bad usage of
+comparison operators.
+
+### Example:
+
+    # bad
+
+    x < y < z
+    10 <= x <= 20
+
+### Example:
+
+    # good
+
+    x < y && y < z
+    10 <= x && x <= 20

--- a/config/contents/lint/nested_method_definition.md
+++ b/config/contents/lint/nested_method_definition.md
@@ -1,10 +1,33 @@
 This cop checks for nested method definitions.
 
 ### Example:
+
+    # bad
+
     # `bar` definition actually produces methods in the same scope
     # as the outer `foo` method. Furthermore, the `bar` method
     # will be redefined every time `foo` is invoked.
     def foo
       def bar
+      end
+    end
+
+### Example:
+
+    # good
+
+    def foo
+      bar = -> { puts 'hello' }
+      bar.call
+    end
+
+### Example:
+
+    # good
+
+    def foo
+      self.class_eval do
+        def bar
+        end
       end
     end

--- a/config/contents/lint/next_without_accumulator.md
+++ b/config/contents/lint/next_without_accumulator.md
@@ -1,13 +1,18 @@
 Don't omit the accumulator when calling `next` in a `reduce` block.
 
 ### Example:
+
     # bad
+
     result = (1..4).reduce(0) do |acc, i|
       next if i.odd?
       acc + i
     end
 
+### Example:
+
     # good
+
     result = (1..4).reduce(0) do |acc, i|
       next acc if i.odd?
       acc + i

--- a/config/contents/lint/parentheses_as_grouped_expression.md
+++ b/config/contents/lint/parentheses_as_grouped_expression.md
@@ -3,4 +3,12 @@ parenthesis.
 
 ### Example:
 
+    # bad
+
     puts (x + y)
+
+### Example:
+
+    # good
+
+    puts(x + y)

--- a/config/contents/lint/percent_string_array.md
+++ b/config/contents/lint/percent_string_array.md
@@ -1,7 +1,17 @@
-This cop checks for quotes and commas in %w, e.g.
+This cop checks for quotes and commas in %w, e.g. `%w('foo', "bar")`
 
-    `%w('foo', "bar")`
-
-it is more likely that the additional characters are unintended (for
+It is more likely that the additional characters are unintended (for
 example, mistranslating an array of literals to percent string notation)
 rather than meant to be part of the resulting strings.
+
+### Example:
+
+    # bad
+
+    %w('foo', "bar")
+
+### Example:
+
+    # good
+
+    %w(foo bar)

--- a/config/contents/lint/percent_symbol_array.md
+++ b/config/contents/lint/percent_symbol_array.md
@@ -1,7 +1,17 @@
-This cop checks for colons and commas in %i, e.g.
+This cop checks for colons and commas in %i, e.g. `%i(:foo, :bar)`
 
-    `%i(:foo, :bar)`
-
-it is more likely that the additional characters are unintended (for
+It is more likely that the additional characters are unintended (for
 example, mistranslating an array of literals to percent string notation)
 rather than meant to be part of the resulting symbols.
+
+### Example:
+
+    # bad
+
+    %i(:foo, :bar)
+
+### Example:
+
+    # good
+
+    %i(foo bar)

--- a/config/contents/lint/rand_one.md
+++ b/config/contents/lint/rand_one.md
@@ -4,10 +4,14 @@ Such calls always return `0`.
 ### Example:
 
     # bad
+
     rand 1
     Kernel.rand(-1)
     rand 1.0
     rand(-1.0)
 
+### Example:
+
     # good
-    0
+
+    0 # just use 0 instead

--- a/config/contents/lint/require_parentheses.md
+++ b/config/contents/lint/require_parentheses.md
@@ -9,6 +9,14 @@ an operand of &&/||.
 
 ### Example:
 
+    # bad
+
     if day.is? :tuesday && month == :jan
       ...
     end
+
+### Example:
+
+    # good
+
+    if day.is?(:tuesday) && month == :jan

--- a/config/contents/lint/rescue_exception.md
+++ b/config/contents/lint/rescue_exception.md
@@ -1,0 +1,21 @@
+This cop checks for *rescue* blocks targeting the Exception class.
+
+### Example:
+
+    # bad
+
+    begin
+      do_something
+    rescue Exception
+      handle_exception
+    end
+
+### Example:
+
+    # good
+
+    begin
+      do_something
+    rescue ArgumentError
+      handle_exception
+    end

--- a/config/contents/lint/safe_navigation_chain.md
+++ b/config/contents/lint/safe_navigation_chain.md
@@ -1,0 +1,20 @@
+The safe navigation operator returns nil if the receiver is
+nil.  If you chain an ordinary method call after a safe
+navigation operator, it raises NoMethodError.  We should use a
+safe navigation operator after a safe navigation operator.
+This cop checks for the problem outlined above.
+
+### Example:
+
+    # bad
+
+    x&.foo.bar
+    x&.foo + bar
+    x&.foo[bar]
+
+### Example:
+
+    # good
+
+    x&.foo&.bar
+    x&.foo || bar

--- a/config/contents/lint/shadowed_exception.md
+++ b/config/contents/lint/shadowed_exception.md
@@ -3,7 +3,9 @@ less specific exception being rescued before a more specific
 exception is rescued.
 
 ### Example:
+
     # bad
+
     begin
       something
     rescue Exception
@@ -12,7 +14,10 @@ exception is rescued.
       handle_standard_error
     end
 
+### Example:
+
     # good
+
     begin
       something
     rescue StandardError

--- a/config/contents/lint/shadowing_outer_local_variable.md
+++ b/config/contents/lint/shadowing_outer_local_variable.md
@@ -2,3 +2,27 @@ This cop looks for use of the same name as outer local variables
 for block arguments or block local variables.
 This is a mimic of the warning
 "shadowing outer local variable - foo" from `ruby -cw`.
+
+### Example:
+
+    # bad
+
+    def some_method
+      foo = 1
+
+      2.times do |foo| # shadowing outer `foo`
+        do_something(foo)
+      end
+    end
+
+### Example:
+
+    # good
+
+    def some_method
+      foo = 1
+
+      2.times do |bar|
+        do_something(bar)
+      end
+    end

--- a/config/contents/lint/string_conversion_in_interpolation.md
+++ b/config/contents/lint/string_conversion_in_interpolation.md
@@ -3,4 +3,12 @@ which is redundant.
 
 ### Example:
 
+    # bad
+
     "result is #{something.to_s}"
+
+### Example:
+
+    # good
+
+    "result is #{something}"

--- a/config/contents/lint/underscore_prefixed_variable_name.md
+++ b/config/contents/lint/underscore_prefixed_variable_name.md
@@ -1,0 +1,26 @@
+This cop checks for underscore-prefixed variables that are actually
+used.
+
+### Example:
+
+    # bad
+
+    [1, 2, 3].each do |_num|
+      do_something(_num)
+    end
+
+### Example:
+
+    # good
+
+    [1, 2, 3].each do |num|
+      do_something(num)
+    end
+
+### Example:
+
+    # good
+
+    [1, 2, 3].each do |_num|
+      do_something # not using `_num`
+    end

--- a/config/contents/lint/unified_integer.md
+++ b/config/contents/lint/unified_integer.md
@@ -1,9 +1,14 @@
 This cop checks for using Fixnum or Bignum constant.
 
 ### Example:
+
     # bad
+
     1.is_a?(Fixnum)
     1.is_a?(Bignum)
 
+### Example:
+
     # good
+
     1.is_a?(Integer)

--- a/config/contents/lint/unneeded_splat_expansion.md
+++ b/config/contents/lint/unneeded_splat_expansion.md
@@ -1,7 +1,9 @@
 This cop checks for unneeded usages of splat expansion
 
 ### Example:
+
     # bad
+
     a = *[1, 2, 3]
     a = *'a'
     a = *1
@@ -19,7 +21,10 @@ This cop checks for unneeded usages of splat expansion
       baz
     end
 
+### Example:
+
     # good
+
     c = [1, 2, 3]
     a = *c
     a, b = *c

--- a/config/contents/lint/unreachable_code.md
+++ b/config/contents/lint/unreachable_code.md
@@ -1,3 +1,20 @@
 This cop checks for unreachable code.
 The check are based on the presence of flow of control
 statement in non-final position in *begin*(implicit) blocks.
+
+### Example:
+
+    # bad
+
+    def some_method
+      return
+      do_something
+    end
+
+### Example:
+
+    # good
+
+    def some_method
+      do_something
+    end

--- a/config/contents/lint/unused_block_argument.md
+++ b/config/contents/lint/unused_block_argument.md
@@ -16,6 +16,8 @@ This cop checks for unused block arguments.
       puts :baz
     end
 
+### Example:
+
     # bad
 
     do_something do |used, _unused|

--- a/config/contents/lint/unused_method_argument.md
+++ b/config/contents/lint/unused_method_argument.md
@@ -2,6 +2,16 @@ This cop checks for unused method arguments.
 
 ### Example:
 
+    # bad
+
     def some_method(used, unused, _unused_but_allowed)
+      puts used
+    end
+
+### Example:
+
+    # good
+
+    def some_method(used, _unused, _unused_but_allowed)
       puts used
     end

--- a/config/contents/lint/useless_access_modifier.md
+++ b/config/contents/lint/useless_access_modifier.md
@@ -73,3 +73,15 @@ are not redundant.
       def some_other_private_method
       end
     end
+
+### Example:
+    # Lint/UselessAccessModifier:
+    #   MethodCreatingMethods:
+    #     - delegate
+    require 'active_support/core_ext/module/delegation'
+    class Foo
+      # this is not redundant because `delegate` creates methods
+      private
+
+      delegate :method_a, to: :method_b
+    end

--- a/config/contents/lint/useless_assignment.md
+++ b/config/contents/lint/useless_assignment.md
@@ -7,3 +7,21 @@ The basic idea for this cop was from the warning of `ruby -cw`:
 Currently this cop has advanced logic that detects unreferenced
 reassignments and properly handles varied cases such as branch, loop,
 rescue, ensure, etc.
+
+### Example:
+
+    # bad
+
+    def some_method
+      some_var = 1
+      do_something
+    end
+
+### Example:
+
+    # good
+
+    def some_method
+      some_var = 1
+      do_something(some_var)
+    end

--- a/config/contents/lint/useless_comparison.md
+++ b/config/contents/lint/useless_comparison.md
@@ -2,4 +2,6 @@ This cop checks for comparison of something with itself.
 
 ### Example:
 
- x.top >= x.top
+    # bad
+
+    x.top >= x.top

--- a/config/contents/lint/useless_else_without_rescue.md
+++ b/config/contents/lint/useless_else_without_rescue.md
@@ -1,8 +1,23 @@
 This cop checks for useless `else` in `begin..end` without `rescue`.
 
 ### Example:
+
+    # bad
+
     begin
       do_something
     else
-      handle_errors # This will never be run.
+      do_something_else # This will never be run.
+    end
+
+### Example:
+
+    # good
+
+    begin
+      do_something
+    rescue
+      handle_errors
+    else
+      do_something_else
     end

--- a/config/contents/lint/useless_setter_call.md
+++ b/config/contents/lint/useless_setter_call.md
@@ -3,7 +3,19 @@ expression of a function definition.
 
 ### Example:
 
- def something
-     x = Something.new
-     x.attr = 5
- end
+    # bad
+
+    def something
+      x = Something.new
+      x.attr = 5
+    end
+
+### Example:
+
+    # good
+
+    def something
+      x = Something.new
+      x.attr = 5
+      x
+    end

--- a/config/contents/lint/void.md
+++ b/config/contents/lint/void.md
@@ -1,0 +1,38 @@
+This cop checks for operators, variables and literals used
+in void context.
+
+### Example:
+
+    # bad
+
+    def some_method
+      some_num * 10
+      do_something
+    end
+
+### Example:
+
+    # bad
+
+    def some_method
+      some_var
+      do_something
+    end
+
+### Example:
+
+    # good
+
+    def some_method
+      do_something
+      some_num * 10
+    end
+
+### Example:
+
+    # good
+
+    def some_method
+      do_something
+      some_var
+    end

--- a/config/contents/metrics/block_length.md
+++ b/config/contents/metrics/block_length.md
@@ -1,3 +1,4 @@
 This cop checks if the length of a block exceeds some maximum value.
 Comment lines can optionally be ignored.
 The maximum allowed length is configurable.
+The cop can be configured to ignore blocks passed to certain methods.

--- a/config/contents/metrics/block_nesting.md
+++ b/config/contents/metrics/block_nesting.md
@@ -1,5 +1,8 @@
 This cop checks for excessive nesting of conditional and looping
-constructs. Despite the cop's name, blocks are not considered as an
-extra level of nesting.
+constructs.
+
+You can configure if blocks are considered using the `CountBlocks`
+option. When set to `false` (the default) blocks are not counted
+towards the nesting level. Set to `true` to count blocks as well.
 
 The maximum level of nesting allowed is configurable.

--- a/config/contents/performance/regexp_match.md
+++ b/config/contents/performance/regexp_match.md
@@ -1,0 +1,55 @@
+In Ruby 2.4, `String#match?`, `Regexp#match?` and `Symbol#match?`
+have been added. The methods are faster than `match`.
+Because the methods avoid creating a `MatchData` object or saving
+backref.
+So, when `MatchData` is not used, use `match?` instead of `match`.
+
+### Example:
+    # bad
+    def foo
+      if x =~ /re/
+        do_something
+      end
+    end
+
+    # bad
+    def foo
+      if x.match(/re/)
+        do_something
+      end
+    end
+
+    # bad
+    def foo
+      if /re/ === x
+        do_something
+      end
+    end
+
+    # good
+    def foo
+      if x.match?(/re/)
+        do_something
+      end
+    end
+
+    # good
+    def foo
+      if x =~ /re/
+        do_something(Regexp.last_match)
+      end
+    end
+
+    # good
+    def foo
+      if x.match(/re/)
+        do_something($~)
+      end
+    end
+
+    # good
+    def foo
+      if /re/ === x
+        do_something($~)
+      end
+    end

--- a/config/contents/rails/file_path.md
+++ b/config/contents/rails/file_path.md
@@ -1,0 +1,11 @@
+This cop is used to identify usages of file path joining process
+to use `Rails.root.join` clause.
+
+### Example:
+ # bad
+ Rails.root.join('app/models/goober')
+ File.join(Rails.root, 'app/models/goober')
+ "#{Rails.root}/app/models/goober"
+
+ # good
+ Rails.root.join('app', 'models', 'goober')

--- a/config/contents/rails/http_positional_arguments.md
+++ b/config/contents/rails/http_positional_arguments.md
@@ -1,6 +1,6 @@
-This cop is used to identify usages of http methods
-like `get`, `post`, `put`, `path` without the usage of keyword arguments
-in your tests and change them to use keyword arguments.
+This cop is used to identify usages of http methods like `get`, `post`,
+`put`, `patch` without the usage of keyword arguments in your tests and
+change them to use keyword arguments.
 
 ### Example:
     # bad

--- a/config/contents/rails/not_null_column.md
+++ b/config/contents/rails/not_null_column.md
@@ -4,7 +4,10 @@ in migration file.
 ### Example:
     # bad
     add_column :users, :name, :string, null: false
+    add_reference :products, :category, null: false
 
     # good
     add_column :users, :name, :string, null: true
     add_column :users, :name, :string, null: false, default: ''
+    add_reference :products, :category
+    add_reference :products, :category, null: false, default: 1

--- a/config/contents/rails/reversible_migration.md
+++ b/config/contents/rails/reversible_migration.md
@@ -1,0 +1,88 @@
+This cop checks whether the change method of the migration file is
+reversible.
+
+### Example:
+    # bad
+    def change
+      change_table :users do |t|
+        t.column :name, :string
+      end
+    end
+
+    # good
+    def change
+      create_table :users do |t|
+        t.string :name
+      end
+    end
+
+    # good
+    def change
+      reversible do |dir|
+        change_table :users do |t|
+          dir.up do
+            t.column :name, :string
+          end
+
+          dir.down do
+            t.remove :name
+          end
+        end
+      end
+    end
+
+### Example:
+    # drop_table
+
+    # bad
+    def change
+      drop_table :users
+    end
+
+    # good
+    def change
+      drop_table :users do |t|
+        t.string :name
+      end
+    end
+
+### Example:
+    # change_column_default
+
+    # bad
+    def change
+      change_column_default(:suppliers, :qualification, 'new')
+    end
+
+    # good
+    def change
+      change_column_default(:posts, :state, from: nil, to: "draft")
+    end
+
+### Example:
+    # remove_column
+
+    # bad
+    def change
+      remove_column(:suppliers, :qualification)
+    end
+
+    # good
+    def change
+      remove_column(:suppliers, :qualification, :string)
+    end
+
+### Example:
+    # remove_foreign_key
+
+    # bad
+    def change
+      remove_foreign_key :accounts, column: :owner_id
+    end
+
+    # good
+    def change
+      remove_foreign_key :accounts, :branches
+    end
+
+@see http://api.rubyonrails.org/classes/ActiveRecord/Migration/CommandRecorder.html

--- a/config/contents/rails/skips_model_validations.md
+++ b/config/contents/rails/skips_model_validations.md
@@ -1,0 +1,19 @@
+This cop checks for the use of methods which skip
+validations which are listed in
+http://guides.rubyonrails.org/active_record_validations.html#skipping-validations
+
+### Example:
+    # bad
+    Article.first.decrement!(:view_count)
+    DiscussionBoard.decrement_counter(:post_count, 5)
+    Article.first.increment!(:view_count)
+    DiscussionBoard.increment_counter(:post_count, 5)
+    person.toggle :active
+    product.touch
+    Billing.update_all("category = 'authorized', author = 'David'")
+    user.update_attribute(website: 'example.com')
+    user.update_columns(last_request_at: Time.current)
+    Post.update_counters 5, comment_count: -1, action_count: 1
+
+    # good
+    user.update_attributes(website: 'example.com')

--- a/config/contents/rails/uniq_before_pluck.md
+++ b/config/contents/rails/uniq_before_pluck.md
@@ -10,11 +10,11 @@ the database.
     # good
     Model.uniq.pluck(:id)
 
-This cop has two different enforcement modes. When the EnforcedMode
+This cop has two different enforcement modes. When the EnforcedStyle
 is conservative (the default) then only calls to pluck on a constant
 (i.e. a model class) before uniq are added as offenses.
 
-When the EnforcedMode is aggressive then all calls to pluck before
+When the EnforcedStyle is aggressive then all calls to pluck before
 uniq are added as offenses. This may lead to false positives as the cop
 cannot distinguish between calls to pluck on an ActiveRecord::Relation
 vs a call to pluck on an ActiveRecord::Associations::CollectionProxy.

--- a/config/contents/security/eval.md
+++ b/config/contents/security/eval.md
@@ -1,0 +1,7 @@
+This cop checks for the use of *Kernel#eval*.
+
+### Example:
+
+    # bad
+
+    eval(something)

--- a/config/contents/security/marshal_load.md
+++ b/config/contents/security/marshal_load.md
@@ -1,0 +1,11 @@
+This cop checks for the use of Marshal class methods which have
+potential security issues leading to remote code execution when
+loading from an untrusted source.
+
+### Example:
+    # bad
+    Marshal.load("{}")
+    Marshal.restore("{}")
+
+    # good
+    Marshal.dump("{}")

--- a/config/contents/security/yaml_load.md
+++ b/config/contents/security/yaml_load.md
@@ -1,0 +1,11 @@
+This cop checks for the use of YAML class methods which have
+potential security issues leading to remote code execution when
+loading from an untrusted source.
+
+### Example:
+    # bad
+    YAML.load("--- foo")
+
+    # good
+    YAML.safe_load("--- foo")
+    YAML.dump("foo")

--- a/config/contents/style/align_hash.md
+++ b/config/contents/style/align_hash.md
@@ -1,0 +1,94 @@
+Check that the keys, separators, and values of a multi-line hash
+literal are aligned according to configuration. The configuration
+options are:
+
+    - key (left align keys)
+    - separator (align hash rockets and colons, right align keys)
+    - table (left align keys, hash rockets, and values)
+
+The treatment of hashes passed as the last argument to a method call
+can also be configured. The options are:
+
+    - always_inspect
+    - always_ignore
+    - ignore_implicit (without curly braces)
+    - ignore_explicit (with curly braces)
+
+### Example:
+
+    # EnforcedHashRocketStyle: key (default)
+    # EnforcedColonStyle: key (default)
+
+    # good
+    {
+      foo: bar,
+      ba: baz
+    }
+    {
+      :foo => bar,
+      :ba => baz
+    }
+
+    # bad
+    {
+      foo: bar,
+       ba: baz
+    }
+    {
+      :foo => bar,
+       :ba => baz
+    }
+
+### Example:
+
+    # EnforcedHashRocketStyle: separator
+    # EnforcedColonStyle: separator
+
+    #good
+    {
+      foo: bar,
+       ba: baz
+    }
+    {
+      :foo => bar,
+       :ba => baz
+    }
+
+    #bad
+    {
+      foo: bar,
+      ba: baz
+    }
+    {
+      :foo => bar,
+      :ba => baz
+    }
+    {
+      :foo => bar,
+      :ba  => baz
+    }
+
+### Example:
+
+    # EnforcedHashRocketStyle: table
+    # EnforcedColonStyle: table
+
+    #good
+    {
+      foo: bar,
+      ba:  baz
+    }
+    {
+      :foo => bar,
+      :ba  => baz
+    }
+
+    #bad
+    {
+      foo: bar,
+      ba: baz
+    }
+    {
+      :foo => bar,
+       :ba => baz
+    }

--- a/config/contents/style/empty_method.md
+++ b/config/contents/style/empty_method.md
@@ -1,6 +1,6 @@
 This cop checks for the formatting of empty method definitions.
 By default it enforces empty method definitions to go on a single
-line (compact style), but it cah be configured to enforce the `end`
+line (compact style), but it can be configured to enforce the `end`
 to go on its own line (expanded style.)
 
 Note: A method definition is not considered empty if it contains
@@ -13,18 +13,24 @@ Note: A method definition is not considered empty if it contains
     # bad
     def foo(bar)
     end
+    def self.foo(bar)
+    end
 
     # good
     def foo(bar); end
     def foo(bar)
       # baz
     end
+    def self.foo(bar); end
 
     EnforcedStyle: expanded
 
     # bad
     def foo(bar); end
+    def self.foo(bar); end
 
     # good
     def foo(bar)
+    end
+    def self.foo(bar)
     end

--- a/config/contents/style/identical_conditional_branches.md
+++ b/config/contents/style/identical_conditional_branches.md
@@ -1,5 +1,5 @@
-This cop checks for identical lines at the end of each branch of a
-conditional statement.
+This cop checks for identical lines at the beginning or end of
+each branch of a conditional statement.
 
 ### Example:
     # bad
@@ -18,3 +18,20 @@ conditional statement.
       do_y
     end
     do_z
+
+    # bad
+    if condition
+      do_z
+      do_x
+    else
+      do_z
+      do_y
+    end
+
+    # good
+    do_z
+    if condition
+      do_x
+    else
+      do_y
+    end

--- a/config/contents/style/method_call_with_args_parentheses.md
+++ b/config/contents/style/method_call_with_args_parentheses.md
@@ -1,0 +1,15 @@
+This cop checks presence of parentheses in method calls containing
+parameters.
+As in popular Ruby's frameworks a lot of methods should always be
+called without parentheses,
+users can ignore them by passing their names to IgnoredMethods option.
+
+### Example:
+    # bad
+    array.delete e
+
+    # good
+    array.delete(e)
+
+    # good if `puts` is listed in IgnoredMethods
+    puts 'test'

--- a/config/contents/style/method_call_without_args_parentheses.md
+++ b/config/contents/style/method_call_without_args_parentheses.md
@@ -1,0 +1,8 @@
+This cop checks for unwanted parentheses in parameterless method calls.
+
+### Example:
+    # bad
+    object.some_method()
+
+    # good
+    object.some_method

--- a/lib/cc/engine/source_file.rb
+++ b/lib/cc/engine/source_file.rb
@@ -32,7 +32,9 @@ module CC
       end
 
       def rubocop_team
-        RuboCop::Cop::Team.new(RuboCop::Cop::Cop.all, config_store)
+        RuboCop::Cop::Team.new(
+          RuboCop::Cop::Registry.new(RuboCop::Cop::Cop.all), config_store
+        )
       end
 
       def display_path


### PR DESCRIPTION
Compare: https://github.com/bbatsov/rubocop/compare/v0.46.0...v0.47.1

The change in the Dockerfile is motivated by this issue and it's
suggested workaround: https://github.com/sickill/rainbow/issues/48

I generated the docs outside of docker because the rake task doesn't
currently work inside docker. I think that's fine.