### PR TITLE
Updated engine and docs for Rubocop v0.52.1.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "activesupport", require: false
 gem "mry", "~> 0.52.0", require: false
 gem "parser", "~> 2.4.0"
 gem "pry", require: false
-gem "rubocop", "~> 0.52.0", require: false
+gem "rubocop", "~> 0.52.1", require: false
 gem "rubocop-migrations", require: false
 gem "rubocop-rspec", require: false
 gem "safe_yaml"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     minitest (5.10.3)
     mry (0.52.0.0)
       rubocop (>= 0.41.0)
-    parallel (1.12.0)
+    parallel (1.12.1)
     parser (2.4.0.2)
       ast (~> 2.3)
     powerpack (0.1.1)
@@ -38,7 +38,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
-    rubocop (0.52.0)
+    rubocop (0.52.1)
       parallel (~> 1.10)
       parser (>= 2.4.0.2, < 3.0)
       powerpack (~> 0.1)
@@ -47,8 +47,8 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     rubocop-migrations (0.1.2)
       rubocop (~> 0.41)
-    rubocop-rspec (1.20.1)
-      rubocop (>= 0.51.0)
+    rubocop-rspec (1.21.0)
+      rubocop (>= 0.52.0)
     ruby-progressbar (1.9.0)
     safe_yaml (1.0.4)
     thread_safe (0.3.6)
@@ -66,10 +66,10 @@ DEPENDENCIES
   pry
   rake
   rspec
-  rubocop (~> 0.52.0)
+  rubocop (~> 0.52.1)
   rubocop-migrations
   rubocop-rspec
   safe_yaml
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ docs: image
 		--user root \
 		--workdir /usr/src/app \
 		--volume $(PWD):/usr/src/app \
-		$(IMAGE_NAME) sh -c "apk --update add git && bundle exec rake docs:scrape"
+		$(IMAGE_NAME) sh -c "apk --update add git && bundle install --with=test && bundle exec rake docs:scrape"

--- a/config/contents/layout/indent_array.md
+++ b/config/contents/layout/indent_array.md
@@ -14,7 +14,7 @@ more than the start of the line where the opening square bracket is.
 This default style is called 'special_inside_parentheses'. Alternative
 styles are 'consistent' and 'align_brackets'. Here are examples:
 
-### Example: EnforcedStyle: special_inside_parentheses
+### Example: EnforcedStyle: special_inside_parentheses (default)
     # The `special_inside_parentheses` style enforces that the first
     # element in an array literal where the opening bracket and first
     # element are on seprate lines is indented one step (two spaces) more

--- a/config/contents/lint/uri_escape_unescape.md
+++ b/config/contents/lint/uri_escape_unescape.md
@@ -12,7 +12,8 @@ depending on your specific use case.
 
     # good
     CGI.escape('http://example.com')
-    URI.encode_www_form('http://example.com')
+    URI.encode_www_form([['example', 'param'], ['lang', 'en']])
+    URI.encode_www_form(page: 10, locale: 'en')
     URI.encode_www_form_component('http://example.com')
 
     # bad

--- a/config/contents/rails/date.md
+++ b/config/contents/rails/date.md
@@ -15,18 +15,26 @@ and 'to_time_in_current_zone' is reported as warning.
 When EnforcedStyle is 'flexible' then only 'Date.today' is prohibited
 and only 'to_time' is reported as warning.
 
-### Example:
-    # no offense
+### Example: EnforcedStyle: strict
+    # bad
+    Date.current
+    Date.yesterday
+    Date.today
+    date.to_time
+    date.to_time_in_current_zone
+
+    # good
     Time.zone.today
     Time.zone.today - 1.day
 
-    # flexible
-    Date.current
-    Date.yesterday
-
-    # always reports offense
+### Example: EnforcedStyle: flexible (default)
+    # bad
     Date.today
     date.to_time
 
-    # reports offense only when style is 'strict'
+    # good
+    Time.zone.today
+    Time.zone.today - 1.day
+    Date.current
+    Date.yesterday
     date.to_time_in_current_zone

--- a/config/contents/rails/inverse_of.md
+++ b/config/contents/rails/inverse_of.md
@@ -5,17 +5,107 @@ queries in some circumstances. `:inverse_of` must be manually specified
 for associations to work in both ways, or set to `false` to opt-out.
 
 ### Example:
+    # good
+    class Blog < ApplicationRecord
+      has_many :posts
+    end
+
+    class Post < ApplicationRecord
+      belongs_to :blog
+    end
+
+### Example:
     # bad
     class Blog < ApplicationRecord
-      has_many :recent_posts, -> { order(published_at: :desc) }
+      has_many :posts, -> { order(published_at: :desc) }
+    end
+
+    class Post < ApplicationRecord
+      belongs_to :blog
     end
 
     # good
     class Blog < ApplicationRecord
-      has_many(:recent_posts,
+      has_many(:posts,
         -> { order(published_at: :desc) },
         inverse_of: :blog
       )
+    end
+
+    class Post < ApplicationRecord
+      belongs_to :blog
+    end
+
+    # good
+    class Blog < ApplicationRecord
+      with_options inverse_of: :blog do
+        has_many :posts, -> { order(published_at: :desc) }
+      end
+    end
+
+    class Post < ApplicationRecord
+      belongs_to :blog
+    end
+
+### Example:
+    # bad
+    class Picture < ApplicationRecord
+      belongs_to :imageable, polymorphic: true
+    end
+
+    class Employee < ApplicationRecord
+      has_many :pictures, as: :imageable
+    end
+
+    class Product < ApplicationRecord
+      has_many :pictures, as: :imageable
+    end
+
+    # good
+    class Picture < ApplicationRecord
+      belongs_to :imageable, polymorphic: true
+    end
+
+    class Employee < ApplicationRecord
+      has_many :pictures, as: :imageable, inverse_of: :imageable
+    end
+
+    class Product < ApplicationRecord
+      has_many :pictures, as: :imageable, inverse_of: :imageable
+    end
+
+### Example:
+    # bad
+    # However, RuboCop can not detect this pattern...
+    class Physician < ApplicationRecord
+      has_many :appointments
+      has_many :patients, through: :appointments
+    end
+
+    class Appointment < ApplicationRecord
+      belongs_to :physician
+      belongs_to :patient
+    end
+
+    class Patient < ApplicationRecord
+      has_many :appointments
+      has_many :physicians, through: :appointments
+    end
+
+    # good
+    class Physician < ApplicationRecord
+      has_many :appointments
+      has_many :patients, through: :appointments
+    end
+
+    class Appointment < ApplicationRecord
+      belongs_to :physician, inverse_of: :appointments
+      belongs_to :patient, inverse_of: :appointments
+    end
+
+    class Patient < ApplicationRecord
+      has_many :appointments
+      has_many :physicians, through: :appointments
     end
 
 @see http://guides.rubyonrails.org/association_basics.html#bi-directional-associations

--- a/config/contents/rails/redundant_receiver_in_with_options.md
+++ b/config/contents/rails/redundant_receiver_in_with_options.md
@@ -21,3 +21,31 @@ Receiver is implicit from Rails 4.2 or higher.
         has_many :expenses
       end
     end
+
+### Example:
+    # bad
+    with_options options: false do |merger|
+      merger.invoke(merger.something)
+    end
+
+    # good
+    with_options options: false do
+      invoke(something)
+    end
+
+    # good
+    client = Client.new
+    with_options options: false do |merger|
+      client.invoke(merger.something, something)
+    end
+
+    # ok
+    # When `with_options` includes a block, all scoping scenarios
+    # cannot be evaluated. Thus, it is ok to include the explicit
+    # receiver.
+    with_options options: false do |merger|
+      merger.invoke
+      with_another_method do |another_receiver|
+        merger.invoke(another_receiver)
+      end
+    end

--- a/config/contents/rails/request_referer.md
+++ b/config/contents/rails/request_referer.md
@@ -1,15 +1,14 @@
 This cop checks for consistent uses of `request.referer` or
 `request.referrer`, depending on the cop's configuration.
 
-### Example:
-    # EnforcedStyle: referer
+### Example: EnforcedStyle: referer (default)
     # bad
     request.referrer
 
     # good
     request.referer
 
-    # EnforcedStyle: referrer
+### Example: EnforcedStyle: referrer
     # bad
     request.referer
 

--- a/config/contents/style/format_string_token.md
+++ b/config/contents/style/format_string_token.md
@@ -1,5 +1,12 @@
 Use a consistent style for named format string tokens.
 
+**Note:**
+`unannotated` style cop only works for strings
+which are passed as arguments to those methods:
+`sprintf`, `format`, `%`.
+The reason is that *unannotated* format is very similar
+to encoded URLs or Date/Time formatting strings.
+
 ### Example: EnforcedStyle: annotated (default)
 
     # bad

--- a/config/contents/style/frozen_string_literal_comment.md
+++ b/config/contents/style/frozen_string_literal_comment.md
@@ -3,3 +3,49 @@ comment `# frozen_string_literal: true` to the top of files to
 enable frozen string literals. Frozen string literals may be default
 in Ruby 3.0. The comment will be added below a shebang and encoding
 comment. The frozen string literal comment is only valid in Ruby 2.3+.
+
+### Example: EnforcedStyle: when_needed (default)
+    # The `when_needed` style will add the frozen string literal comment
+    # to files only when the `TargetRubyVersion` is set to 2.3+.
+    # bad
+    module Foo
+      # ...
+    end
+
+    # good
+    # frozen_string_literal: true
+
+    module Foo
+      # ...
+    end
+
+### Example: EnforcedStyle: always
+    # The `always` style will always add the frozen string literal comment
+    # to a file, regardless of the Ruby version or if `freeze` or `<<` are
+    # called on a string literal.
+    # bad
+    module Bar
+      # ...
+    end
+
+    # good
+    # frozen_string_literal: true
+
+    module Bar
+      # ...
+    end
+
+### Example: EnforcedStyle: never
+    # The `never` will enforce that the frozen string literal comment does
+    # not exist in a file.
+    # bad
+    # frozen_string_literal: true
+
+    module Baz
+      # ...
+    end
+
+    # good
+    module Baz
+      # ...
+    end

--- a/config/contents/style/if_unless_modifier.md
+++ b/config/contents/style/if_unless_modifier.md
@@ -1,3 +1,17 @@
 Checks for if and unless statements that would fit on one line
 if written as a modifier if/unless. The maximum line length is
 configured in the `Metrics/LineLength` cop.
+
+### Example:
+    # bad
+    if condition
+      do_stuff(bar)
+    end
+
+    unless qux.empty?
+      Foo.do_something
+    end
+
+    # good
+    do_stuff(bar) if condition
+    Foo.do_something unless qux.empty?

--- a/config/contents/style/method_def_parentheses.md
+++ b/config/contents/style/method_def_parentheses.md
@@ -1,0 +1,81 @@
+This cops checks for parentheses around the arguments in method
+definitions. Both instance and class/singleton methods are checked.
+
+### Example: EnforcedStyle: require_parentheses (default)
+    # The `require_parentheses` style requires method definitions
+    # to always use parentheses
+
+    # bad
+    def bar num1, num2
+      num1 + num2
+    end
+
+    def foo descriptive_var_name,
+            another_descriptive_var_name,
+            last_descriptive_var_name
+      do_something
+    end
+
+    # good
+    def bar(num1, num2)
+      num1 + num2
+    end
+
+    def foo(descriptive_var_name,
+            another_descriptive_var_name,
+            last_descriptive_var_name)
+      do_something
+    end
+
+### Example: EnforcedStyle: require_no_parentheses
+    # The `require_no_parentheses` style requires method definitions
+    # to never use parentheses
+
+    # bad
+    def bar(num1, num2)
+      num1 + num2
+    end
+
+    def foo(descriptive_var_name,
+            another_descriptive_var_name,
+            last_descriptive_var_name)
+      do_something
+    end
+
+    # good
+    def bar num1, num2
+      num1 + num2
+    end
+
+    def foo descriptive_var_name,
+            another_descriptive_var_name,
+            last_descriptive_var_name
+      do_something
+    end
+
+### Example: EnforcedStyle: require_no_parentheses_except_multiline
+    # The `require_no_parentheses_except_multiline` style prefers no
+    # parantheses when method definition arguments fit on single line,
+    # but prefers parantheses when arguments span multiple lines.
+
+    # bad
+    def bar(num1, num2)
+      num1 + num2
+    end
+
+    def foo descriptive_var_name,
+            another_descriptive_var_name,
+            last_descriptive_var_name
+      do_something
+    end
+
+    # good
+    def bar num1, num2
+      num1 + num2
+    end
+
+    def foo(descriptive_var_name,
+            another_descriptive_var_name,
+            last_descriptive_var_name)
+      do_something
+    end

--- a/config/contents/style/multiline_ternary_operator.md
+++ b/config/contents/style/multiline_ternary_operator.md
@@ -1,0 +1,20 @@
+This cop checks for multi-line ternary op expressions.
+
+### Example:
+    # bad
+    a = cond ?
+      b : c
+    a = cond ? b :
+        c
+    a = cond ?
+        b :
+        c
+
+    # good
+    a = cond ? b : c
+    a =
+      if cond
+        b
+      else
+        c
+      end

--- a/spec/support/currently_undocumented_cops.txt
+++ b/spec/support/currently_undocumented_cops.txt
@@ -14,8 +14,6 @@ RuboCop::Cop::Style::BeginBlock
 RuboCop::Cop::Style::ConditionalAssignment
 RuboCop::Cop::Style::Encoding
 RuboCop::Cop::Style::EndBlock
-RuboCop::Cop::Style::MethodDefParentheses
-RuboCop::Cop::Style::MultilineTernaryOperator
 RuboCop::Cop::Style::NegatedWhile
 RuboCop::Cop::Style::NestedTernaryOperator
 RuboCop::Cop::Style::OneLineConditional


### PR DESCRIPTION
The change to the Makefile is to avoid this issue with building the docs, caused by `rake` being in the `:test` Gemfile group.

```Executing busybox-1.24.2-r13.trigger
OK: 38 MiB in 34 packages
bundler: failed to load command: rake (/usr/local/bin/rake)
Gem::Exception: can't find executable rake for gem rake. rake is not currently included in the bundle, perhaps you meant to add it to your Gemfile?
  /usr/local/bundle/gems/bundler-1.16.1/lib/bundler/rubygems_integration.rb:458:in `block in replace_bin_path'
  /usr/local/bundle/gems/bundler-1.16.1/lib/bundler/rubygems_integration.rb:478:in `block in replace_bin_path'
  /usr/local/bin/rake:23:in `<top (required)>'
make: *** [docs] Error 1
```