### PR TITLE
RuboCop v0.54.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,10 @@
 source 'https://rubygems.org'
 
 gem "activesupport", require: false
-gem "mry", "~> 0.52.0", require: false
-gem "parser", "~> 2.4.0"
+gem "mry", "~> 0.54.0", require: false
+gem "parser", "~> 2.5.0"
 gem "pry", require: false
-gem "rubocop", "~> 0.52.1", require: false
+gem "rubocop", "~> 0.54.0", require: false
 gem "rubocop-migrations", require: false
 gem "rubocop-rspec", require: false
 gem "safe_yaml"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    ast (2.3.0)
+    ast (2.4.0)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
@@ -14,11 +14,11 @@ GEM
       concurrent-ruby (~> 1.0)
     method_source (0.9.0)
     minitest (5.10.3)
-    mry (0.52.0.0)
+    mry (0.54.0.0)
       rubocop (>= 0.41.0)
     parallel (1.12.1)
-    parser (2.4.0.2)
-      ast (~> 2.3)
+    parser (2.5.0.5)
+      ast (~> 2.4.0)
     powerpack (0.1.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -38,17 +38,17 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
-    rubocop (0.52.1)
+    rubocop (0.54.0)
       parallel (~> 1.10)
-      parser (>= 2.4.0.2, < 3.0)
+      parser (>= 2.5)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     rubocop-migrations (0.1.2)
       rubocop (~> 0.41)
-    rubocop-rspec (1.21.0)
-      rubocop (>= 0.52.0)
+    rubocop-rspec (1.25.0)
+      rubocop (>= 0.53.0)
     ruby-progressbar (1.9.0)
     safe_yaml (1.0.4)
     thread_safe (0.3.6)
@@ -61,12 +61,12 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
-  mry (~> 0.52.0)
-  parser (~> 2.4.0)
+  mry (~> 0.54.0)
+  parser (~> 2.5.0)
   pry
   rake
   rspec
-  rubocop (~> 0.52.1)
+  rubocop (~> 0.54.0)
   rubocop-migrations
   rubocop-rspec
   safe_yaml

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,9 @@ docs: image
 		--workdir /usr/src/app \
 		--volume $(PWD):/usr/src/app \
 		$(IMAGE_NAME) sh -c "apk --update add git && bundle install --with=test && bundle exec rake docs:scrape"
+
+bundle:
+	docker run --rm \
+		--entrypoint /bin/sh \
+		--volume $(PWD):/usr/src/app \
+		$(IMAGE_NAME) -c "bundle $(BUNDLE_ARGS)"

--- a/config/contents/layout/align_hash.md
+++ b/config/contents/layout/align_hash.md
@@ -14,81 +14,148 @@ can also be configured. The options are:
     - ignore_implicit (without curly braces)
     - ignore_explicit (with curly braces)
 
-### Example:
+### Example: EnforcedHashRocketStyle: key (default)
+    # bad
+    {
+      :foo => bar,
+       :ba => baz
+    }
 
-    # EnforcedHashRocketStyle: key (default)
-    # EnforcedColonStyle: key (default)
+    # good
+    {
+      :foo => bar,
+      :ba => baz
+    }
+
+### Example: EnforcedHashRocketStyle: separator
+    # bad
+    {
+      :foo => bar,
+      :ba => baz
+    }
+    {
+      :foo => bar,
+      :ba  => baz
+    }
+
+    # good
+    {
+      :foo => bar,
+       :ba => baz
+    }
+
+### Example: EnforcedHashRocketStyle: table
+    # bad
+    {
+      :foo => bar,
+       :ba => baz
+    }
+
+    # good
+    {
+      :foo => bar,
+      :ba  => baz
+    }
+
+### Example: EnforcedColonStyle: key (default)
+    # bad
+    {
+      foo: bar,
+       ba: baz
+    }
 
     # good
     {
       foo: bar,
       ba: baz
     }
-    {
-      :foo => bar,
-      :ba => baz
-    }
 
+### Example: EnforcedColonStyle: separator
     # bad
-    {
-      foo: bar,
-       ba: baz
-    }
-    {
-      :foo => bar,
-       :ba => baz
-    }
-
-### Example:
-
-    # EnforcedHashRocketStyle: separator
-    # EnforcedColonStyle: separator
-
-    #good
-    {
-      foo: bar,
-       ba: baz
-    }
-    {
-      :foo => bar,
-       :ba => baz
-    }
-
-    #bad
     {
       foo: bar,
       ba: baz
     }
+
+    # good
     {
-      :foo => bar,
-      :ba => baz
-    }
-    {
-      :foo => bar,
-      :ba  => baz
+      foo: bar,
+       ba: baz
     }
 
-### Example:
+### Example: EnforcedColonStyle: table
+    # bad
+    {
+      foo: bar,
+      ba: baz
+    }
 
-    # EnforcedHashRocketStyle: table
-    # EnforcedColonStyle: table
-
-    #good
+    # good
     {
       foo: bar,
       ba:  baz
     }
-    {
-      :foo => bar,
-      :ba  => baz
-    }
 
-    #bad
-    {
-      foo: bar,
-      ba: baz
-    }
-    {
-      :foo => bar,
-       :ba => baz
-    }
+### Example: EnforcedLastArgumentHashStyle: always_inspect (default)
+    # Inspect both implicit and explicit hashes.
+
+    # bad
+    do_something(foo: 1,
+      bar: 2)
+
+    # bad
+    do_something({foo: 1,
+      bar: 2})
+
+    # good
+    do_something(foo: 1,
+                 bar: 2)
+
+    # good
+    do_something(
+      foo: 1,
+      bar: 2
+    )
+
+    # good
+    do_something({foo: 1,
+                  bar: 2})
+
+    # good
+    do_something({
+      foo: 1,
+      bar: 2
+    })
+
+### Example: EnforcedLastArgumentHashStyle: always_ignore
+    # Ignore both implicit and explicit hashes.
+
+    # good
+    do_something(foo: 1,
+      bar: 2)
+
+    # good
+    do_something({foo: 1,
+      bar: 2})
+
+### Example: EnforcedLastArgumentHashStyle: ignore_implicit
+    # Ignore only implicit hashes.
+
+    # bad
+    do_something({foo: 1,
+      bar: 2})
+
+    # good
+    do_something(foo: 1,
+      bar: 2)
+
+### Example: EnforcedLastArgumentHashStyle: ignore_explicit
+    # Ignore only explicit hashes.
+
+    # bad
+    do_something(foo: 1,
+      bar: 2)
+
+    # good
+    do_something({foo: 1,
+      bar: 2})

--- a/config/contents/layout/block_alignment.md
+++ b/config/contents/layout/block_alignment.md
@@ -1,0 +1,58 @@
+This cop checks whether the end keywords are aligned properly for do
+end blocks.
+
+Three modes are supported through the `EnforcedStyleAlignWith`
+configuration parameter:
+
+`start_of_block` : the `end` shall be aligned with the
+start of the line where the `do` appeared.
+
+`start_of_line` : the `end` shall be aligned with the
+start of the line where the expression started.
+
+`either` (which is the default) : the `end` is allowed to be in either
+location. The autofixer will default to `start_of_line`.
+
+### Example: EnforcedStyleAlignWith: either (default)
+    # bad
+
+    foo.bar
+       .each do
+         baz
+           end
+
+    # good
+
+    variable = lambda do |i|
+      i
+    end
+
+### Example: EnforcedStyleAlignWith: start_of_block
+    # bad
+
+    foo.bar
+       .each do
+         baz
+           end
+
+    # good
+
+    foo.bar
+      .each do
+         baz
+       end
+
+### Example: EnforcedStyleAlignWith: start_of_line
+    # bad
+
+    foo.bar
+       .each do
+         baz
+           end
+
+    # good
+
+    foo.bar
+      .each do
+         baz
+    end

--- a/config/contents/layout/condition_position.md
+++ b/config/contents/layout/condition_position.md
@@ -1,0 +1,19 @@
+This cop checks for conditions that are not on the same line as
+if/while/until.
+
+### Example:
+
+    # bad
+
+    if
+      some_condition
+      do_something
+    end
+
+### Example:
+
+    # good
+
+    if some_condition
+      do_something
+    end

--- a/config/contents/layout/def_end_alignment.md
+++ b/config/contents/layout/def_end_alignment.md
@@ -1,0 +1,30 @@
+This cop checks whether the end keywords of method definitions are
+aligned properly.
+
+Two modes are supported through the EnforcedStyleAlignWith configuration
+parameter. If it's set to `start_of_line` (which is the default), the
+`end` shall be aligned with the start of the line where the `def`
+keyword is. If it's set to `def`, the `end` shall be aligned with the
+`def` keyword.
+
+### Example: EnforcedStyleAlignWith: start_of_line (default)
+    # bad
+
+    private def foo
+                end
+
+    # good
+
+    private def foo
+    end
+
+### Example: EnforcedStyleAlignWith: def
+    # bad
+
+    private def foo
+                end
+
+    # good
+
+    private def foo
+            end

--- a/config/contents/layout/empty_comment.md
+++ b/config/contents/layout/empty_comment.md
@@ -1,0 +1,56 @@
+This cop checks empty comment.
+
+### Example:
+    # bad
+
+    #
+    class Foo
+    end
+
+    # good
+
+    #
+    # Description of `Foo` class.
+    #
+    class Foo
+    end
+
+### Example: AllowBorderComment: true (default)
+    # good
+
+    def foo
+    end
+
+    #################
+
+    def bar
+    end
+
+### Example: AllowBorderComment: false
+    # bad
+
+    def foo
+    end
+
+    #################
+
+    def bar
+    end
+
+### Example: AllowMarginComment: true (default)
+    # good
+
+    #
+    # Description of `Foo` class.
+    #
+    class Foo
+    end
+
+### Example: AllowMarginComment: false
+    # bad
+
+    #
+    # Description of `Foo` class.
+    #
+    class Foo
+    end

--- a/config/contents/layout/empty_lines_around_class_body.md
+++ b/config/contents/layout/empty_lines_around_class_body.md
@@ -31,6 +31,26 @@ the configuration.
 
     end
 
+### Example: Enforcedstyle: beginning_only
+    # good
+
+    class Foo
+
+      def bar
+        # ...
+      end
+    end
+
+### Example: Enforcedstyle: ending_only
+    # good
+
+    class Foo
+      def bar
+        # ...
+      end
+
+    end
+
 ### Example: EnforcedStyle: no_empty_lines (default)
     # good
 

--- a/config/contents/layout/end_alignment.md
+++ b/config/contents/layout/end_alignment.md
@@ -1,0 +1,64 @@
+This cop checks whether the end keywords are aligned properly.
+
+Three modes are supported through the `EnforcedStyleAlignWith`
+configuration parameter:
+
+If it's set to `keyword` (which is the default), the `end`
+shall be aligned with the start of the keyword (if, class, etc.).
+
+If it's set to `variable` the `end` shall be aligned with the
+left-hand-side of the variable assignment, if there is one.
+
+If it's set to `start_of_line`, the `end` shall be aligned with the
+start of the line where the matching keyword appears.
+
+### Example: EnforcedStyleAlignWith: keyword (default)
+    # bad
+
+    variable = if true
+        end
+
+    # good
+
+    variable = if true
+               end
+
+    variable =
+      if true
+      end
+
+### Example: EnforcedStyleAlignWith: variable
+    # bad
+
+    variable = if true
+        end
+
+    # good
+
+    variable = if true
+    end
+
+    variable =
+      if true
+      end
+
+### Example: EnforcedStyleAlignWith: start_of_line
+    # bad
+
+    variable = if true
+        end
+
+    puts(if true
+         end)
+
+    # good
+
+    variable = if true
+    end
+
+    puts(if true
+    end)
+
+    variable =
+      if true
+      end

--- a/config/contents/layout/indent_heredoc.md
+++ b/config/contents/layout/indent_heredoc.md
@@ -7,13 +7,31 @@ Note: When `Metrics/LineLength`'s `AllowHeredoc` is false(not default),
         this cop does not add any offenses for long here documents to
         avoid `Metrics/LineLength`'s offenses.
 
-### Example:
-
+### Example: EnforcedStyle: auto_detection (default)
     # bad
     <<-RUBY
     something
     RUBY
 
+    # good
+    # When using Ruby 2.3 or higher.
+    <<~RUBY
+      something
+    RUBY
+
+    # good
+    # When using Ruby 2.2 or lower and enabled Rails department.
+    # The following is possible to enable Rails department by
+    # adding for example:
+    #
+    # Rails:
+    #   Enabled: true
+    #
+    <<-RUBY.strip_heredoc
+      something
+    RUBY
+
+### Example: EnforcedStyle: squiggly
     # good
     # When EnforcedStyle is squiggly, bad code is auto-corrected to the
     # following code.
@@ -21,9 +39,26 @@ Note: When `Metrics/LineLength`'s `AllowHeredoc` is false(not default),
       something
     RUBY
 
+### Example: EnforcedStyle: active_support
     # good
     # When EnforcedStyle is active_support, bad code is auto-corrected to
     # the following code.
     <<-RUBY.strip_heredoc
+      something
+    RUBY
+
+### Example: EnforcedStyle: powerpack
+    # good
+    # When EnforcedStyle is powerpack, bad code is auto-corrected to
+    # the following code.
+    <<-RUBY.strip_indent
+      something
+    RUBY
+
+### Example: EnforcedStyle: unindent
+    # good
+    # When EnforcedStyle is unindent, bad code is auto-corrected to
+    # the following code.
+    <<-RUBY.unindent
       something
     RUBY

--- a/config/contents/layout/indentation_consistency.md
+++ b/config/contents/layout/indentation_consistency.md
@@ -1,10 +1,114 @@
 This cops checks for inconsistent indentation.
 
-### Example:
+The difference between `rails` and `normal` is that the `rails` style
+prescribes that in classes and modules the `protected` and `private`
+modifier keywords shall be indented the same as public methods and that
+protected and private members shall be indented one step more than the
+modifiers. Other than that, both styles mean that entities on the same
+logical depth shall have the same indentation.
 
+### Example: EnforcedStyle: normal (default)
+    # bad
     class A
       def test
         puts 'hello'
          puts 'world'
       end
+    end
+
+    # bad
+    class A
+      def test
+        puts 'hello'
+        puts 'world'
+      end
+
+      protected
+
+        def foo
+        end
+
+      private
+
+        def bar
+        end
+    end
+
+    # good
+    class A
+      def test
+        puts 'hello'
+        puts 'world'
+      end
+    end
+
+    # good
+    class A
+      def test
+        puts 'hello'
+        puts 'world'
+      end
+
+      protected
+
+      def foo
+      end
+
+      private
+
+      def bar
+      end
+    end
+
+### Example: EnforcedStyle: rails
+    # bad
+    class A
+      def test
+        puts 'hello'
+         puts 'world'
+      end
+    end
+
+    # bad
+    class A
+      def test
+        puts 'hello'
+        puts 'world'
+      end
+
+      protected
+
+      def foo
+      end
+
+      private
+
+      def bar
+      end
+    end
+
+    # good
+    class A
+      def test
+        puts 'hello'
+        puts 'world'
+      end
+    end
+
+    # good
+    class A
+      def test
+        puts 'hello'
+        puts 'world'
+      end
+
+      protected
+
+        def foo
+        end
+
+      private
+
+        def bar
+        end
     end

--- a/config/contents/layout/initial_indentation.md
+++ b/config/contents/layout/initial_indentation.md
@@ -1,0 +1,13 @@
+This cops checks for indentation of the first non-blank non-comment
+line in a file.
+
+### Example:
+    # bad
+       class A
+         def foo; end
+       end
+
+    # good
+    class A
+      def foo; end
+    end

--- a/config/contents/layout/multiline_method_call_brace_layout.md
+++ b/config/contents/layout/multiline_method_call_brace_layout.md
@@ -21,32 +21,65 @@ When using the `same_line` style:
 The closing brace of a multi-line method call must be on the same
 line as the last argument of the call.
 
-### Example:
+### Example: EnforcedStyle: symmetrical (default)
+    # bad
+    foo(a,
+      b
+    )
 
-      # symmetrical: bad
-      # new_line: good
-      # same_line: bad
-      foo(a,
-        b
-      )
+    # bad
+    foo(
+      a,
+      b)
 
-      # symmetrical: bad
-      # new_line: bad
-      # same_line: good
-      foo(
-        a,
-        b)
+    # good
+    foo(a,
+      b)
 
-      # symmetrical: good
-      # new_line: bad
-      # same_line: good
-      foo(a,
-        b)
+    # good
+    foo(
+      a,
+      b
+    )
 
-      # symmetrical: good
-      # new_line: good
-      # same_line: bad
-      foo(
-        a,
-        b
-      )
+### Example: EnforcedStyle: new_line
+    # bad
+    foo(
+      a,
+      b)
+
+    # bad
+    foo(a,
+      b)
+
+    # good
+    foo(a,
+      b
+    )
+
+    # good
+    foo(
+      a,
+      b
+    )
+
+### Example: EnforcedStyle: same_line
+    # bad
+    foo(a,
+      b
+    )
+
+    # bad
+    foo(
+      a,
+      b
+    )
+
+    # good
+    foo(
+      a,
+      b)
+
+    # good
+    foo(a,
+      b)

--- a/config/contents/layout/multiline_method_call_indentation.md
+++ b/config/contents/layout/multiline_method_call_indentation.md
@@ -1,7 +1,7 @@
 This cop checks the indentation of the method name part in method calls
 that span more than one line.
 
-### Example: EnforcedStyle: aligned
+### Example: EnforcedStyle: aligned (default)
     # bad
     while myvariable
     .b

--- a/config/contents/layout/multiline_method_definition_brace_layout.md
+++ b/config/contents/layout/multiline_method_definition_brace_layout.md
@@ -21,36 +21,77 @@ When using the `same_line` style:
 The closing brace of a multi-line method definition must be on the same
 line as the last parameter of the definition.
 
-### Example:
+### Example: EnforcedStyle: symmetrical (default)
+    # bad
+    def foo(a,
+      b
+    )
+    end
 
-      # symmetrical: bad
-      # new_line: good
-      # same_line: bad
-      def foo(a,
-        b
-      )
-      end
+    # bad
+    def foo(
+      a,
+      b)
+    end
 
-      # symmetrical: bad
-      # new_line: bad
-      # same_line: good
-      def foo(
-        a,
-        b)
-      end
+    # good
+    def foo(a,
+      b)
+    end
 
-      # symmetrical: good
-      # new_line: bad
-      # same_line: good
-      def foo(a,
-        b)
-      end
+    # good
+    def foo(
+      a,
+      b
+    )
+    end
 
-      # symmetrical: good
-      # new_line: good
-      # same_line: bad
-      def foo(
-        a,
-        b
-      )
-      end
+### Example: EnforcedStyle: new_line
+    # bad
+    def foo(
+      a,
+      b)
+    end
+
+    # bad
+    def foo(a,
+      b)
+    end
+
+    # good
+    def foo(a,
+      b
+    )
+    end
+
+    # good
+    def foo(
+      a,
+      b
+    )
+    end
+
+### Example: EnforcedStyle: same_line
+    # bad
+    def foo(a,
+      b
+    )
+    end
+
+    # bad
+    def foo(
+      a,
+      b
+    )
+    end
+
+    # good
+    def foo(
+      a,
+      b)
+    end
+
+    # good
+    def foo(a,
+      b)
+    end

--- a/config/contents/layout/multiline_operation_indentation.md
+++ b/config/contents/layout/multiline_operation_indentation.md
@@ -1,15 +1,28 @@
 This cop checks the indentation of the right hand side operand in
 binary operations that span more than one line.
 
-### Example:
+### Example: EnforcedStyle: aligned (default)
     # bad
     if a +
-    b
+        b
       something
     end
 
     # good
     if a +
        b
+      something
+    end
+
+### Example: EnforcedStyle: indented
+    # bad
+    if a +
+       b
+      something
+    end
+
+    # good
+    if a +
+        b
       something
     end

--- a/config/contents/layout/space_around_equals_in_parameter_default.md
+++ b/config/contents/layout/space_around_equals_in_parameter_default.md
@@ -1,6 +1,7 @@
 Checks that the equals signs in parameter default assignments
 have or don't have surrounding space depending on configuration.
-### Example:
+
+### Example: EnforcedStyle: space (default)
     # bad
     def some_method(arg1=:default, arg2=nil, arg3=[])
       # do something...
@@ -8,5 +9,16 @@ have or don't have surrounding space depending on configuration.
 
     # good
     def some_method(arg1 = :default, arg2 = nil, arg3 = [])
+      # do something...
+    end
+
+### Example: EnforcedStyle: no_space
+    # bad
+    def some_method(arg1 = :default, arg2 = nil, arg3 = [])
+      # do something...
+    end
+
+    # good
+    def some_method(arg1=:default, arg2=nil, arg3=[])
       # do something...
     end

--- a/config/contents/layout/space_before_block_braces.md
+++ b/config/contents/layout/space_before_block_braces.md
@@ -1,7 +1,7 @@
 Checks that block braces have or don't have a space before the opening
 brace depending on configuration.
 
-### Example:
+### Example: EnforcedStyle: space (default)
     # bad
     foo.map{ |a|
       a.bar.to_s
@@ -9,5 +9,16 @@ brace depending on configuration.
 
     # good
     foo.map { |a|
+      a.bar.to_s
+    }
+
+### Example: EnforcedStyle: no_space
+    # bad
+    foo.map { |a|
+      a.bar.to_s
+    }
+
+    # good
+    foo.map{ |a|
       a.bar.to_s
     }

--- a/config/contents/layout/space_inside_array_literal_brackets.md
+++ b/config/contents/layout/space_inside_array_literal_brackets.md
@@ -11,7 +11,7 @@ surrounding space depending on configuration.
     # good
     array = [ a, b, c, d ]
 
-### Example: EnforcedStyle: no_space
+### Example: EnforcedStyle: no_space (default)
     # The `no_space` style enforces that array literals have
     # no surrounding space.
 
@@ -31,3 +31,28 @@ surrounding space depending on configuration.
 
     # good
     array = [ a, [ b, c ]]
+
+
+### Example: EnforcedStyleForEmptyBrackets: no_space (default)
+    # The `no_space` EnforcedStyleForEmptyBrackets style enforces that
+    # empty array brackets do not contain spaces.
+
+    # bad
+    foo = [ ]
+    bar = [     ]
+
+    # good
+    foo = []
+    bar = []
+
+### Example: EnforcedStyleForEmptyBrackets: space
+    # The `space` EnforcedStyleForEmptyBrackets style enforces that
+    # empty array brackets contain exactly one space.
+
+    # bad
+    foo = []
+    bar = [    ]
+
+    # good
+    foo = [ ]
+    bar = [ ]

--- a/config/contents/layout/space_inside_block_braces.md
+++ b/config/contents/layout/space_inside_block_braces.md
@@ -38,7 +38,7 @@ configuration.
 
 ### Example: EnforcedStyleForEmptyBraces: space
     # The `space` EnforcedStyleForEmptyBraces style enforces that
-    # block braces have at least a spece in between when empty.
+    # block braces have at least a space in between when empty.
 
     # bad
     some_array.each {}
@@ -60,7 +60,7 @@ configuration.
     # good
     [1, 2, 3].each { |n| n * 2 }
 
-### Example: SpaceBeforeBlockParameters: true
+### Example: SpaceBeforeBlockParameters: false
     # The SpaceBeforeBlockParameters style set to `false` enforces that
     # there is no space between `{` and `|`. Overrides `EnforcedStyle`
     # if there is a conflict.

--- a/config/contents/layout/space_inside_hash_literal_braces.md
+++ b/config/contents/layout/space_inside_hash_literal_braces.md
@@ -1,7 +1,7 @@
 Checks that braces used for hash literals have or don't have
 surrounding space depending on configuration.
 
-### Example: EnforcedStyle: space
+### Example: EnforcedStyle: space (default)
     # The `space` style enforces that hash literals have
     # surrounding space.
 
@@ -31,3 +31,28 @@ surrounding space depending on configuration.
 
     # good
     h = { a: { b: 2 }}
+
+
+### Example: EnforcedStyleForEmptyBraces: no_space (default)
+    # The `no_space` EnforcedStyleForEmptyBraces style enforces that
+    # empty hash braces do not contain spaces.
+
+    # bad
+    foo = { }
+    bar = {    }
+
+    # good
+    foo = {}
+    bar = {}
+
+### Example: EnforcedStyleForEmptyBraces: space
+    # The `space` EnforcedStyleForEmptyBraces style enforces that
+    # empty hash braces contain space.
+
+    # bad
+    foo = {}
+
+    # good
+    foo = { }
+    foo = {  }
+    foo = {     }

--- a/config/contents/layout/space_inside_reference_brackets.md
+++ b/config/contents/layout/space_inside_reference_brackets.md
@@ -24,3 +24,26 @@ surrounding space depending on configuration.
     # good
     hash[ :key ]
     array[ index ]
+
+
+### Example: EnforcedStyleForEmptyBrackets: no_space (default)
+    # The `no_space` EnforcedStyleForEmptyBrackets style enforces that
+    # empty reference brackets do not contain spaces.
+
+    # bad
+    foo[ ]
+    foo[     ]
+
+    # good
+    foo[]
+
+### Example: EnforcedStyleForEmptyBrackets: space
+    # The `space` EnforcedStyleForEmptyBrackets style enforces that
+    # empty reference brackets contain exactly one space.
+
+    # bad
+    foo[]
+    foo[    ]
+
+    # good
+    foo[ ]

--- a/config/contents/layout/tab.md
+++ b/config/contents/layout/tab.md
@@ -1,0 +1,14 @@
+This cop checks for tabs inside the source code.
+
+### Example:
+    # bad
+    # This example uses a tab to indent bar.
+    def foo
+      bar
+    end
+
+    # good
+    # This example uses spaces to indent bar.
+    def foo
+      bar
+    end

--- a/config/contents/layout/trailing_blank_lines.md
+++ b/config/contents/layout/trailing_blank_lines.md
@@ -1,0 +1,33 @@
+This cop looks for trailing blank lines and a final newline in the
+source code.
+
+### Example: EnforcedStyle: final_blank_line
+    # `final_blank_line` looks for one blank line followed by a new line
+    # at the end of files.
+
+    # bad
+    class Foo; end
+    # EOF
+
+    # bad
+    class Foo; end # EOF
+
+    # good
+    class Foo; end
+
+    # EOF
+
+### Example: EnforcedStyle: final_newline (default)
+    # `final_newline` looks for one newline at the end of files.
+
+    # bad
+    class Foo; end
+
+    # EOF
+
+    # bad
+    class Foo; end # EOF
+
+    # good
+    class Foo; end
+    # EOF

--- a/config/contents/layout/trailing_whitespace.md
+++ b/config/contents/layout/trailing_whitespace.md
@@ -1,0 +1,10 @@
+This cop looks for trailing whitespace in the source code.
+
+### Example:
+    # The line in this example contains spaces after the 0.
+    # bad
+    x = 0
+
+    # The line in this example ends directly after the 0.
+    # good
+    x = 0

--- a/config/contents/lint/big_decimal_new.md
+++ b/config/contents/lint/big_decimal_new.md
@@ -1,0 +1,10 @@
+`BigDecimal.new()` is deprecated since BigDecimal 1.3.3.
+This cop identifies places where `BigDecimal.new()`
+can be replaced by `BigDecimal()`.
+
+### Example:
+    # bad
+    BigDecimal.new(123.456, 3)
+
+    # good
+    BigDecimal(123.456, 3)

--- a/config/contents/lint/duplicate_methods.md
+++ b/config/contents/lint/duplicate_methods.md
@@ -5,11 +5,11 @@ definitions.
 
     # bad
 
-    def duplicated
+    def foo
       1
     end
 
-    def duplicated
+    def foo
       2
     end
 
@@ -17,20 +17,30 @@ definitions.
 
     # bad
 
-    def duplicated
+    def foo
       1
     end
 
-    alias duplicated other_duplicated
+    alias foo bar
 
 ### Example:
 
     # good
 
-    def duplicated
+    def foo
       1
     end
 
-    def other_duplicated
+    def bar
       2
     end
+
+### Example:
+
+    # good
+
+    def foo
+      1
+    end
+
+    alias bar foo

--- a/config/contents/lint/number_conversion.md
+++ b/config/contents/lint/number_conversion.md
@@ -1,0 +1,17 @@
+This cop warns the usage of unsafe number conversions. Unsafe
+number conversion can cause unexpected error if auto type conversion
+fails. Cop prefer parsing with number class instead.
+
+### Example:
+
+    # bad
+
+    '10'.to_i
+    '10.2'.to_f
+    '10'.to_c
+
+    # good
+
+    Integer('10', 10)
+    Float('10.2')
+    Complex('10')

--- a/config/contents/lint/ordered_magic_comments.md
+++ b/config/contents/lint/ordered_magic_comments.md
@@ -1,0 +1,23 @@
+
+Checks the proper ordering of magic comments and whether
+a magic comment is not placed before a shebang.
+
+### Example:
+    # bad
+
+    # frozen_string_literal: true
+    # encoding: ascii
+    p [''.frozen?, ''.encoding] #=> [true, #<Encoding:UTF-8>]
+
+    # good
+
+    # encoding: ascii
+    # frozen_string_literal: true
+    p [''.frozen?, ''.encoding] #=> [true, #<Encoding:US-ASCII>]
+
+    # good
+
+    #!/usr/bin/env ruby
+    # encoding: ascii
+    # frozen_string_literal: true
+    p [''.frozen?, ''.encoding] #=> [true, #<Encoding:US-ASCII>]

--- a/config/contents/lint/script_permission.md
+++ b/config/contents/lint/script_permission.md
@@ -1,0 +1,26 @@
+This cop checks if a file which has a shebang line as
+its first line is granted execute permission.
+
+### Example:
+    # bad
+
+    # A file which has a shebang line as its first line is not
+    # granted execute permission.
+
+    #!/usr/bin/env ruby
+    puts 'hello, world'
+
+    # good
+
+    # A file which has a shebang line as its first line is
+    # granted execute permission.
+
+    #!/usr/bin/env ruby
+    puts 'hello, world'
+
+    # good
+
+    # A file which has not a shebang line as its first line is not
+    # granted execute permission.
+
+    puts 'hello, world'

--- a/config/contents/lint/unneeded_cop_disable_directive.md
+++ b/config/contents/lint/unneeded_cop_disable_directive.md
@@ -1,0 +1,3 @@
+# The Lint/UnneededCopDisableDirective cop needs to be disabled so as
+# to be able to provide a (bad) example of an unneeded disable.
+# rubocop:disable Lint/UnneededCopDisableDirective

--- a/config/contents/lint/unneeded_cop_enable_directive.md
+++ b/config/contents/lint/unneeded_cop_enable_directive.md
@@ -1,0 +1,3 @@
+# The Lint/UnneededCopEnableDirective cop needs to be disabled so as
+# to be able to provide a (bad) example of an unneeded enable.
+# rubocop:disable Lint/UnneededCopEnableDirective

--- a/config/contents/lint/void.md
+++ b/config/contents/lint/void.md
@@ -1,5 +1,5 @@
-This cop checks for operators, variables and literals used
-in void context.
+This cop checks for operators, variables, literals, and nonmutating
+methods used in void context.
 
 ### Example:
 
@@ -21,6 +21,15 @@ in void context.
 
 ### Example:
 
+    # bad, when CheckForMethodsWithNoSideEffects is set true
+
+    def some_method(some_array)
+      some_array.sort
+      do_something(some_array)
+    end
+
+### Example:
+
     # good
 
     def some_method
@@ -35,4 +44,13 @@ in void context.
     def some_method(some_var)
       do_something
       some_var
+    end
+
+### Example:
+
+    # good, when CheckForMethodsWithNoSideEffects is set true
+
+    def some_method(some_array)
+      some_array.sort!
+      do_something(some_array)
     end

--- a/config/contents/naming/memoized_instance_variable_name.md
+++ b/config/contents/naming/memoized_instance_variable_name.md
@@ -1,0 +1,28 @@
+This cop checks for memoized methods whose instance variable name
+does not match the method name.
+
+### Example:
+    # bad
+    # Method foo is memoized using an instance variable that is
+    # not `@foo`. This can cause confusion and bugs.
+    def foo
+      @something ||= calculate_expensive_thing
+    end
+
+    # good
+    def foo
+      @foo ||= calculate_expensive_thing
+    end
+
+    # good
+    def foo
+      @foo ||= begin
+        calculate_expensive_thing
+      end
+    end
+
+    # good
+    def foo
+      helper_variable = something_we_need_to_calculate_foo
+      @foo ||= calculate_expensive_thing(helper_variable)
+    end

--- a/config/contents/naming/uncommunicative_block_param_name.md
+++ b/config/contents/naming/uncommunicative_block_param_name.md
@@ -1,0 +1,32 @@
+This cop checks block parameter names for how descriptive they
+are. It is highly configurable.
+
+The `MinNameLength` config option takes an integer. It represents
+the minimum amount of characters the name must be. Its default is 1.
+The `AllowNamesEndingInNumbers` config option takes a boolean. When
+set to false, this cop will register offenses for names ending with
+numbers. Its default is false. The `AllowedNames` config option
+takes an array of whitelisted names that will never register an
+offense. The `ForbiddenNames` config option takes an array of
+blacklisted names that will always register an offense.
+
+### Example:
+    # bad
+    bar do |varOne, varTwo|
+      varOne + varTwo
+    end
+
+    # With `AllowNamesEndingInNumbers` set to false
+    foo { |num1, num2| num1 * num2 }
+
+    # With `MinParamNameLength` set to number greater than 1
+    baz { |a, b, c| do_stuff(a, b, c) }
+
+    # good
+    bar do |thud, fred|
+      thud + fred
+    end
+
+    foo { |speed, distance| speed * distance }
+
+    baz { |age, height, gender| do_stuff(age, height, gender) }

--- a/config/contents/naming/uncommunicative_method_param_name.md
+++ b/config/contents/naming/uncommunicative_method_param_name.md
@@ -1,0 +1,40 @@
+This cop checks method parameter names for how descriptive they
+are. It is highly configurable.
+
+The `MinNameLength` config option takes an integer. It represents
+the minimum amount of characters the name must be. Its default is 3.
+The `AllowNamesEndingInNumbers` config option takes a boolean. When
+set to false, this cop will register offenses for names ending with
+numbers. Its default is false. The `AllowedNames` config option
+takes an array of whitelisted names that will never register an
+offense. The `ForbiddenNames` config option takes an array of
+blacklisted names that will always register an offense.
+
+### Example:
+    # bad
+    def bar(varOne, varTwo)
+      varOne + varTwo
+    end
+
+    # With `AllowNamesEndingInNumbers` set to false
+    def foo(num1, num2)
+      num1 * num2
+    end
+
+    # With `MinArgNameLength` set to number greater than 1
+    def baz(a, b, c)
+      do_stuff(a, b, c)
+    end
+
+    # good
+    def bar(thud, fred)
+      thud + fred
+    end
+
+    def foo(speed, distance)
+      speed * distance
+    end
+
+    def baz(age_a, height_b, gender_c)
+      do_stuff(age_a, height_b, gender_c)
+    end

--- a/config/contents/performance/fixed_size.md
+++ b/config/contents/performance/fixed_size.md
@@ -1,0 +1,41 @@
+Do not compute the size of statically sized objects.
+
+### Example:
+    # String methods
+    # bad
+    'foo'.size
+    %q[bar].count
+    %(qux).length
+
+    # Symbol methods
+    # bad
+    :fred.size
+    :'baz'.length
+
+    # Array methods
+    # bad
+    [1, 2, thud].count
+    %W(1, 2, bar).size
+
+    # Hash methods
+    # bad
+    { a: corge, b: grault }.length
+
+    # good
+    foo.size
+    bar.count
+    qux.length
+
+    # good
+    :"#{fred}".size
+    CONST = :baz.length
+
+    # good
+    [1, 2, *thud].count
+    garply = [1, 2, 3]
+    garly.size
+
+    # good
+    { a: corge, **grault }.length
+    waldo = { a: corge, b: grault }
+    waldo.size

--- a/config/contents/rails/active_record_aliases.md
+++ b/config/contents/rails/active_record_aliases.md
@@ -1,0 +1,9 @@
+Checks that ActiveRecord aliases are not used. The direct method names
+are more clear and easier to read.
+
+### Example:
+    #bad
+    Book.update_attributes!(author: 'Alice')
+
+    #good
+    Book.update!(author: 'Alice')

--- a/config/contents/rails/file_path.md
+++ b/config/contents/rails/file_path.md
@@ -1,5 +1,6 @@
 This cop is used to identify usages of file path joining process
-to use `Rails.root.join` clause.
+to use `Rails.root.join` clause. This is to avoid bugs on operating
+system that don't use '/' as the path separator.
 
 ### Example:
  # bad

--- a/config/contents/rails/http_status.md
+++ b/config/contents/rails/http_status.md
@@ -1,0 +1,27 @@
+Enforces use of symbolic or numeric value to define HTTP status.
+
+### Example: `EnforcedStyle: symbolic` (default)
+    # bad
+    render :foo, status: 200
+    render json: { foo: 'bar' }, status: 200
+    render plain: 'foo/bar', status: 304
+    redirect_to root_url, status: 301
+
+    # good
+    render :foo, status: :ok
+    render json: { foo: 'bar' }, status: :ok
+    render plain: 'foo/bar', status: :not_modified
+    redirect_to root_url, status: :moved_permanently
+
+### Example: `EnforcedStyle: numeric`
+    # bad
+    render :foo, status: :ok
+    render json: { foo: 'bar' }, status: :not_found
+    render plain: 'foo/bar', status: :not_modified
+    redirect_to root_url, status: :moved_permanently
+
+    # good
+    render :foo, status: 200
+    render json: { foo: 'bar' }, status: 404
+    render plain: 'foo/bar', status: 304
+    redirect_to root_url, status: 301

--- a/config/contents/rails/inverse_of.md
+++ b/config/contents/rails/inverse_of.md
@@ -2,7 +2,8 @@ This cop looks for has_(one|many) and belongs_to associations where
 ActiveRecord can't automatically determine the inverse association
 because of a scope or the options used. This can result in unnecessary
 queries in some circumstances. `:inverse_of` must be manually specified
-for associations to work in both ways, or set to `false` to opt-out.
+for associations to work in both ways, or set to `false` or `nil`
+to opt-out.
 
 ### Example:
     # good
@@ -45,6 +46,24 @@ for associations to work in both ways, or set to `false` to opt-out.
 
     class Post < ApplicationRecord
       belongs_to :blog
+    end
+
+    # good
+    # When you don't want to use the inverse association.
+    class Blog < ApplicationRecord
+      has_many(:posts,
+        -> { order(published_at: :desc) },
+        inverse_of: false
+      )
+    end
+
+    # good
+    # You can also opt-out with specifying `inverse_of: nil`.
+    class Blog < ApplicationRecord
+      has_many(:posts,
+        -> { order(published_at: :desc) },
+        inverse_of: nil
+      )
     end
 
 ### Example:

--- a/config/contents/rails/lexically_scoped_action_filter.md
+++ b/config/contents/rails/lexically_scoped_action_filter.md
@@ -1,10 +1,10 @@
 This cop checks that methods specified in the filter's `only`
-or `except` options are explicitly defined in the controller.
+or `except` options are explicitly defined in the class or module.
 
 You can specify methods of superclass or methods added by mixins
 on the filter, but these confuse developers. If you specify methods
-where are defined on another controller, you should define the filter
-in that controller.
+where are defined on another classes or modules, you should define
+the filter in that class or module.
 
 ### Example:
     # bad
@@ -26,5 +26,28 @@ in that controller.
       end
 
       def logout
+      end
+    end
+
+### Example:
+    # bad
+    module FooMixin
+      extend ActiveSupport::Concern
+
+      included do
+        before_action proc { authenticate }, only: :foo
+      end
+    end
+
+    # good
+    module FooMixin
+      extend ActiveSupport::Concern
+
+      included do
+        before_action proc { authenticate }, only: :foo
+      end
+
+      def foo
+        # something
       end
     end

--- a/config/contents/rails/skips_model_validations.md
+++ b/config/contents/rails/skips_model_validations.md
@@ -11,10 +11,10 @@ http://guides.rubyonrails.org/active_record_validations.html#skipping-validation
     person.toggle :active
     product.touch
     Billing.update_all("category = 'authorized', author = 'David'")
-    user.update_attribute(website: 'example.com')
+    user.update_attribute(:website, 'example.com')
     user.update_columns(last_request_at: Time.current)
     Post.update_counters 5, comment_count: -1, action_count: 1
 
     # good
-    user.update_attributes(website: 'example.com')
+    user.update(website: 'example.com')
     FileUtils.touch('file')

--- a/config/contents/rails/time_zone.md
+++ b/config/contents/rails/time_zone.md
@@ -9,16 +9,32 @@ then only use of Time.zone is allowed.
 When EnforcedStyle is 'flexible' then it's also allowed
 to use Time.in_time_zone.
 
-### Example:
-    # always offense
+### Example: EnforcedStyle: strict
+    # `strict` means that `Time` should be used with `zone`.
+
+    # bad
     Time.now
     Time.parse('2015-03-02 19:05:37')
 
-    # no offense
+    # bad
+    Time.current
+    Time.at(timestamp).in_time_zone
+
+    # good
     Time.zone.now
     Time.zone.parse('2015-03-02 19:05:37')
 
-    # no offense only if style is 'flexible'
+### Example: EnforcedStyle: flexible (default)
+    # `flexible` allows usage of `in_time_zone` instead of `zone`.
+
+    # bad
+    Time.now
+    Time.parse('2015-03-02 19:05:37')
+
+    # good
+    Time.zone.now
+    Time.zone.parse('2015-03-02 19:05:37')
+
+    # good
     Time.current
-    DateTime.strptime(str, "%Y-%m-%d %H:%M %Z").in_time_zone
     Time.at(timestamp).in_time_zone

--- a/config/contents/rails/uniq_before_pluck.md
+++ b/config/contents/rails/uniq_before_pluck.md
@@ -3,13 +3,6 @@ Prefer the use of uniq (or distinct), before pluck instead of after.
 The use of uniq before pluck is preferred because it executes within
 the database.
 
-### Example:
-    # bad
-    Model.pluck(:id).uniq
-
-    # good
-    Model.uniq.pluck(:id)
-
 This cop has two different enforcement modes. When the EnforcedStyle
 is conservative (the default) then only calls to pluck on a constant
 (i.e. a model class) before uniq are added as offenses.
@@ -19,12 +12,27 @@ uniq are added as offenses. This may lead to false positives as the cop
 cannot distinguish between calls to pluck on an ActiveRecord::Relation
 vs a call to pluck on an ActiveRecord::Associations::CollectionProxy.
 
-### Example:
+Autocorrect is disabled by default for this cop since it may generate
+false positives.
+
+### Example: EnforcedStyle: conservative (default)
+    # bad
+    Model.pluck(:id).uniq
+
+    # good
+    Model.uniq.pluck(:id)
+
+### Example: EnforcedStyle: aggressive
+    # bad
     # this will return a Relation that pluck is called on
     Model.where(cond: true).pluck(:id).uniq
 
+    # bad
     # an association on an instance will return a CollectionProxy
     instance.assoc.pluck(:id).uniq
 
-Autocorrect is disabled by default for this cop since it may generate
-false positives.
+    # bad
+    Model.pluck(:id).uniq
+
+    # good
+    Model.uniq.pluck(:id)

--- a/config/contents/rails/validation.md
+++ b/config/contents/rails/validation.md
@@ -1,0 +1,26 @@
+This cop checks for the use of old-style attribute validation macros.
+
+### Example:
+    # bad
+    validates_acceptance_of :foo
+    validates_confirmation_of :foo
+    validates_exclusion_of :foo
+    validates_format_of :foo
+    validates_inclusion_of :foo
+    validates_length_of :foo
+    validates_numericality_of :foo
+    validates_presence_of :foo
+    validates_size_of :foo
+    validates_uniqueness_of :foo
+
+    # good
+    validates :foo, acceptance: true
+    validates :foo, confirmation: true
+    validates :foo, exclusion: true
+    validates :foo, format: true
+    validates :foo, inclusion: true
+    validates :foo, length: true
+    validates :foo, numericality: true
+    validates :foo, presence: true
+    validates :foo, size: true
+    validates :foo, uniqueness: true

--- a/config/contents/security/open.md
+++ b/config/contents/security/open.md
@@ -1,0 +1,14 @@
+This cop checks for the use of `Kernel#open`.
+`Kernel#open` enables not only file access but also process invocation
+by prefixing a pipe symbol (e.g., `open("| ls")`).  So, it may lead to
+a serious security risk by using variable input to the argument of
+`Kernel#open`.  It would be better to use `File.open` or `IO.popen`
+explicitly.
+
+### Example:
+    # bad
+    open(something)
+
+    # good
+    File.open(something)
+    IO.popen(something)

--- a/config/contents/style/class_vars.md
+++ b/config/contents/style/class_vars.md
@@ -1,3 +1,25 @@
 This cop checks for uses of class variables. Offenses
 are signaled only on assignment to class variables to
 reduce the number of offenses that would be reported.
+
+Setting value for class variable need to take care.
+If some class has been inherited by other classes, setting value
+for class variable affected children classes.
+So using class instance variable is better in almost case.
+
+### Example:
+    # bad
+    class A
+      @@test = 10
+    end
+
+    # good
+    class A
+      @test = 10
+    end
+
+    class A
+      def test
+        @@test # you can access class variable without offence
+      end
+    end

--- a/config/contents/style/empty_line_after_guard_clause.md
+++ b/config/contents/style/empty_line_after_guard_clause.md
@@ -1,0 +1,32 @@
+This cop enforces empty line after guard clause
+
+### Example:
+
+    # bad
+    def foo
+      return if need_return?
+      bar
+    end
+
+    # good
+    def foo
+      return if need_return?
+
+      bar
+    end
+
+    # good
+    def foo
+      return if something?
+      return if something_different?
+
+      bar
+    end
+
+    # also good
+    def foo
+      if something?
+        do_something
+        return if need_return?
+      end
+    end

--- a/config/contents/style/expand_path_arguments.md
+++ b/config/contents/style/expand_path_arguments.md
@@ -1,0 +1,36 @@
+This cop checks for use of the `File.expand_path` arguments.
+Likewise, it also checks for the `Pathname.new` argument.
+
+Contrastive bad case and good case are alternately shown in
+the following examples.
+
+### Example:
+    # bad
+    File.expand_path('..', __FILE__)
+
+    # good
+    File.expand_path(__dir__)
+
+    # bad
+    File.expand_path('../..', __FILE__)
+
+    # good
+    File.expand_path('..', __dir__)
+
+    # bad
+    File.expand_path('.', __FILE__)
+
+    # good
+    File.expand_path(__FILE__)
+
+    # bad
+    Pathname(__FILE__).parent.expand_path
+
+    # good
+    Pathname(__dir__).expand_path
+
+    # bad
+    Pathname.new(__FILE__).parent.expand_path
+
+    # good
+    Pathname.new(__dir__).expand_path

--- a/config/contents/style/for.md
+++ b/config/contents/style/for.md
@@ -2,3 +2,33 @@ This cop looks for uses of the *for* keyword, or *each* method. The
 preferred alternative is set in the EnforcedStyle configuration
 parameter. An *each* call with a block on a single line is always
 allowed, however.
+
+### Example: EnforcedStyle: each (default)
+    # bad
+    def foo
+      for n in [1, 2, 3] do
+        puts n
+      end
+    end
+
+    # good
+    def foo
+      [1, 2, 3].each do |n|
+        puts n
+      end
+    end
+
+### Example: EnforcedStyle: for
+    # bad
+    def foo
+      [1, 2, 3].each do |n|
+        puts n
+      end
+    end
+
+    # good
+    def foo
+      for n in [1, 2, 3] do
+        puts n
+      end
+    end

--- a/config/contents/style/format_string.md
+++ b/config/contents/style/format_string.md
@@ -6,7 +6,7 @@ manner for all cases, so only two scenarios are considered -
 if the first argument is a string literal and if the second
 argument is an array literal.
 
-### Example: EnforcedStyle: format(default)
+### Example: EnforcedStyle: format (default)
     # bad
     puts sprintf('%10s', 'hoge')
     puts '%10s' % 'hoge'

--- a/config/contents/style/inverse_methods.md
+++ b/config/contents/style/inverse_methods.md
@@ -22,3 +22,4 @@ of the block that is passed to the method should be defined in
     foo != bar
     foo == bar
     !!('foo' =~ /^\w+$/)
+    !(foo.class < Numeric) # Checking class hierarchy is allowed

--- a/config/contents/style/missing_else.md
+++ b/config/contents/style/missing_else.md
@@ -1,25 +1,90 @@
 Checks for `if` expressions that do not have an `else` branch.
-SupportedStyles
 
-if
-### Example:
+Supported styles are: if, case, both.
+
+### Example: EnforcedStyle: if
+    # warn when an `if` expression is missing an `else` branch.
+
     # bad
     if condition
       statement
     end
 
-case
-### Example:
+    # good
+    if condition
+      statement
+    else
+      # the content of `else` branch will be determined by Style/EmptyElse
+    end
+
+    # good
+    case var
+    when condition
+      statement
+    end
+
+    # good
+    case var
+    when condition
+      statement
+    else
+      # the content of `else` branch will be determined by Style/EmptyElse
+    end
+
+### Example: EnforcedStyle: case
+    # warn when a `case` expression is missing an `else` branch.
+
     # bad
     case var
     when condition
       statement
     end
 
-### Example:
+    # good
+    case var
+    when condition
+      statement
+    else
+      # the content of `else` branch will be determined by Style/EmptyElse
+    end
+
+    # good
+    if condition
+      statement
+    end
+
     # good
     if condition
       statement
     else
-    # the content of the else branch will be determined by Style/EmptyElse
+      # the content of `else` branch will be determined by Style/EmptyElse
+    end
+
+### Example: EnforcedStyle: both (default)
+    # warn when an `if` or `case` expression is missing an `else` branch.
+
+    # bad
+    if condition
+      statement
+    end
+
+    # bad
+    case var
+    when condition
+      statement
+    end
+
+    # good
+    if condition
+      statement
+    else
+      # the content of `else` branch will be determined by Style/EmptyElse
+    end
+
+    # good
+    case var
+    when condition
+      statement
+    else
+      # the content of `else` branch will be determined by Style/EmptyElse
     end

--- a/config/contents/style/mixin_usage.md
+++ b/config/contents/style/mixin_usage.md
@@ -1,8 +1,6 @@
-This cop checks that `include`, `extend` and `prepend` exists at
-the top level.
-Using these at the top level affects the behavior of `Object`.
-There will not be using `include`, `extend` and `prepend` at
-the top level. Let's use it inside `class` or `module`.
+This cop checks that `include`, `extend` and `prepend` statements appear
+inside classes and modules, not at the top level, so as to not affect
+the behavior of `Object`.
 
 ### Example:
     # bad

--- a/config/contents/style/redundant_begin.md
+++ b/config/contents/style/redundant_begin.md
@@ -4,6 +4,7 @@ Currently it checks for code like this:
 
 ### Example:
 
+    # bad
     def redundant
       begin
         ala
@@ -13,9 +14,28 @@ Currently it checks for code like this:
       end
     end
 
+    # good
     def preferred
       ala
       bala
     rescue StandardError => e
       something
+    end
+
+    # bad
+    # When using Ruby 2.5 or later.
+    do_something do
+      begin
+        something
+      rescue => ex
+        anything
+      end
+    end
+
+    # good
+    # In Ruby 2.5 or later, you can omit `begin` in `do-end` block.
+    do_something do
+      something
+    rescue => ex
+      anything
     end

--- a/config/contents/style/redundant_return.md
+++ b/config/contents/style/redundant_return.md
@@ -1,11 +1,15 @@
 This cop checks for redundant `return` expressions.
 
 ### Example:
+    # These bad cases should be extended to handle methods whose body is
+    # if/else or a case expression with a default branch.
 
+    # bad
     def test
       return something
     end
 
+    # bad
     def test
       one
       two
@@ -13,5 +17,15 @@ This cop checks for redundant `return` expressions.
       return something
     end
 
-It should be extended to handle methods whose body is if/else
-or a case expression with a default branch.
+    # good
+    def test
+      return something if something_else
+    end
+
+    # good
+    def test
+      if x
+      elsif y
+      else
+      end
+    end

--- a/config/contents/style/trailing_body_on_class.md
+++ b/config/contents/style/trailing_body_on_class.md
@@ -1,0 +1,11 @@
+This cop checks for trailing code after the class definition.
+
+### Example:
+    # bad
+    class Foo; def foo; end
+    end
+
+    # good
+    class Foo
+      def foo; end
+    end

--- a/config/contents/style/trailing_body_on_module.md
+++ b/config/contents/style/trailing_body_on_module.md
@@ -1,0 +1,11 @@
+This cop checks for trailing code after the module definition.
+
+### Example:
+    # bad
+    module Foo extend self
+    end
+
+    # good
+    module Foo
+      extend self
+    end

--- a/config/contents/style/trailing_comma_in_array_literal.md
+++ b/config/contents/style/trailing_comma_in_array_literal.md
@@ -1,0 +1,37 @@
+This cop checks for trailing comma in array literals.
+
+### Example: EnforcedStyleForMultiline: consistent_comma
+    # bad
+    a = [1, 2,]
+
+    # good
+    a = [
+      1, 2,
+      3,
+    ]
+
+    # good
+    a = [
+      1,
+      2,
+    ]
+
+### Example: EnforcedStyleForMultiline: comma
+    # bad
+    a = [1, 2,]
+
+    # good
+    a = [
+      1,
+      2,
+    ]
+
+### Example: EnforcedStyleForMultiline: no_comma (default)
+    # bad
+    a = [1, 2,]
+
+    # good
+    a = [
+      1,
+      2
+    ]

--- a/config/contents/style/trailing_comma_in_hash_literal.md
+++ b/config/contents/style/trailing_comma_in_hash_literal.md
@@ -1,0 +1,37 @@
+This cop checks for trailing comma in hash literals.
+
+### Example: EnforcedStyleForMultiline: consistent_comma
+    # bad
+    a = { foo: 1, bar: 2, }
+
+    # good
+    a = {
+      foo: 1, bar: 2,
+      qux: 3,
+    }
+
+    # good
+    a = {
+      foo: 1,
+      bar: 2,
+    }
+
+### Example: EnforcedStyleForMultiline: comma
+    # bad
+    a = { foo: 1, bar: 2, }
+
+    # good
+    a = {
+      foo: 1,
+      bar: 2,
+    }
+
+### Example: EnforcedStyleForMultiline: no_comma (default)
+    # bad
+    a = { foo: 1, bar: 2, }
+
+    # good
+    a = {
+      foo: 1,
+      bar: 2
+    }

--- a/config/contents/style/unpack_first.md
+++ b/config/contents/style/unpack_first.md
@@ -1,0 +1,14 @@
+This cop checks for accessing the first element of `String#unpack`
+which can be replaced with the shorter method `unpack1`.
+
+### Example:
+
+    # bad
+    'foo'.unpack('h*').first
+    'foo'.unpack('h*')[0]
+    'foo'.unpack('h*').slice(0)
+    'foo'.unpack('h*').at(0)
+    'foo'.unpack('h*').take(1)
+
+    # good
+    'foo'.unpack1('h*')

--- a/spec/support/currently_undocumented_cops.txt
+++ b/spec/support/currently_undocumented_cops.txt
@@ -1,15 +1,8 @@
 RuboCop::Cop::Layout::EndOfLine
-RuboCop::Cop::Layout::InitialIndentation
 RuboCop::Cop::Layout::SpaceInsideBrackets
-RuboCop::Cop::Layout::Tab
-RuboCop::Cop::Layout::TrailingBlankLines
-RuboCop::Cop::Layout::TrailingWhitespace
 RuboCop::Cop::Lint::MissingCopEnableDirective
-RuboCop::Cop::Lint::ScriptPermission
 RuboCop::Cop::Lint::Syntax
 RuboCop::Cop::Metrics::LineLength
-RuboCop::Cop::Performance::FixedSize
-RuboCop::Cop::Rails::Validation
 RuboCop::Cop::Style::BeginBlock
 RuboCop::Cop::Style::ConditionalAssignment
 RuboCop::Cop::Style::Encoding


### PR DESCRIPTION
Create a new channel for RuboCop v0.54.0 ([changelog](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0540-2018-03-21)), including regenerated documentation.

Other change: add a `make bundle` command.