### PR TITLE
Install basic build dependencies prior to building gems.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,12 @@ RUN adduser -u 9000 -D app
 
 COPY Gemfile Gemfile.lock /usr/src/app/
 
-RUN gem install bundler && \
-    bundle install -j 4 --without=test && \
+RUN apk add --update build-base && \
+    gem install bundler && \
+    bundle install --quiet -j 4 --without=test && \
     chown -R app:app /usr/local/bundle && \
-    rm -fr ~/.gem ~/.bundle ~/.wh..gem
+    rm -fr ~/.gem ~/.bundle ~/.wh..gem && \
+    apk del build-base
 
 COPY . /usr/src/app
 RUN chown -R app:app .


### PR DESCRIPTION
Rubocop versions after 0.56.x have a native gem dependency.
The `build-base` package provides the necessary toolchain.
We remove it after use to reduce the size of the image.