### PR TITLE
Bump channel/rubocop-0-63 to use rubocop 0.63.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
-    rubocop (0.63.0)
+    rubocop (0.63.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
@@ -74,4 +74,4 @@ DEPENDENCIES
   safe_yaml
 
 BUNDLED WITH
-   1.16.6
+   1.17.2


### PR DESCRIPTION
RuboCop 0.63.1 has been released.
https://github.com/rubocop-hq/rubocop/releases/tag/v0.63.1

This PR performed the following steps with reference to #128.

```console
git checkout channel/rubocop-0-63
make image
git checkout -b update_0_63_1
docker run --user root --rm --volume "$(pwd)":/usr/src/app --workdir
/usr/src/app codeclimate/codeclimate-rubocop bundle update rubocop
make docs
make test
```