### PR TITLE
Fix version when creating version specific channels

### DIFF
--- a/bin/newver
+++ b/bin/newver
@@ -15,7 +15,7 @@ ed Gemfile <<-EDITS
 gem "parser"
 .
 /gem "rubocop",/c
-gem "rubocop", "~> ${NEWVER}", require: false
+gem "rubocop", "${NEWVER}", require: false
 .
 wq
 EDITS


### PR DESCRIPTION
Using `~>` allows for minor version update which is fine when updating to latest, but gets
the wrong version when newer one is available.