### PR TITLE
Fix docs:scrape regex to skip forward to class definition

### DIFF
--- a/config/contents/bundler/insecure_protocol_source.md
+++ b/config/contents/bundler/insecure_protocol_source.md
@@ -1,4 +1,4 @@
-The symbol argument `:gemcutter`, `:rubygems`, and `:rubyforge`
+The symbol argument `:gemcutter`, `:rubygems` and `:rubyforge`
 are deprecated. So please change your source to URL string that
 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
 

--- a/config/contents/gemspec/duplicated_assignment.md
+++ b/config/contents/gemspec/duplicated_assignment.md
@@ -3,7 +3,7 @@ in a gemspec.
 
 Assigning to an attribute with the same name using `spec.foo =` will be
 an unintended usage. On the other hand, duplication of methods such
-as `spec.requirements`, `spec.add_runtime_dependency`, and others are
+as `spec.requirements`, `spec.add_runtime_dependency` and others are
 permitted because it is the intended use of appending values.
 
 ### Example:

--- a/config/contents/layout/access_modifier_indentation.md
+++ b/config/contents/layout/access_modifier_indentation.md
@@ -1,6 +1,5 @@
-Bare access modifiers (those not applying to specific methods) should be
-indented as deep as method definitions, or as deep as the class/module
-keyword, depending on configuration.
+Modifiers should be indented as deep as method definitions, or as deep
+as the class/module keyword, depending on configuration.
 
 ### Example: EnforcedStyle: indent (default)
     # bad

--- a/config/contents/layout/align_hash.md
+++ b/config/contents/layout/align_hash.md
@@ -2,7 +2,7 @@ Check that the keys, separators, and values of a multi-line hash
 literal are aligned according to configuration. The configuration
 options are:
 
-    - key (left align keys, one space before hash rockets and values)
+    - key (left align keys)
     - separator (align hash rockets and colons, right align keys)
     - table (left align keys, hash rockets, and values)
 
@@ -19,10 +19,6 @@ can also be configured. The options are:
     {
       :foo => bar,
        :ba => baz
-    }
-    {
-      :foo => bar,
-      :ba  => baz
     }
 
     # good
@@ -66,10 +62,6 @@ can also be configured. The options are:
     {
       foo: bar,
        ba: baz
-    }
-    {
-      foo: bar,
-      ba:  baz
     }
 
     # good

--- a/config/contents/layout/align_parameters.md
+++ b/config/contents/layout/align_parameters.md
@@ -1,65 +1,24 @@
 Here we check if the parameters on a multi-line method call or
 definition are aligned.
 
-To set the alignment of the first argument, use the cop
-FirstParameterIndentation.
-
 ### Example: EnforcedStyle: with_first_parameter (default)
     # good
 
-    def foo(bar,
-            baz)
-      123
-    end
-
-    def foo(
-      bar,
-      baz
-    )
-      123
-    end
+    foo :bar,
+        :baz
 
     # bad
 
-    def foo(bar,
-         baz)
-      123
-    end
-
-    # bad
-
-    def foo(
-      bar,
-         baz)
-      123
-    end
+    foo :bar,
+      :baz
 
 ### Example: EnforcedStyle: with_fixed_indentation
     # good
 
-    def foo(bar,
-      baz)
-      123
-    end
-
-    def foo(
-      bar,
-      baz
-    )
-      123
-    end
+    foo :bar,
+      :baz
 
     # bad
 
-    def foo(bar,
-            baz)
-      123
-    end
-
-    # bad
-
-    def foo(
-      bar,
-         baz)
-      123
-    end
+    foo :bar,
+        :baz

--- a/config/contents/layout/class_structure.md
+++ b/config/contents/layout/class_structure.md
@@ -3,43 +3,35 @@ Checks if the code style follows the ExpectedOrder configuration:
 `Categories` allows us to map macro names into a category.
 
 Consider an example of code style that covers the following order:
-- Module inclusion (include, prepend, extend)
 - Constants
 - Associations (has_one, has_many)
-- Public attribute macros (attr_accessor, attr_writer, attr_reader)
-- Other macros (validates, validate)
-- Public class methods
+- Attributes (attr_accessor, attr_writer, attr_reader)
 - Initializer
-- Public instance methods
-- Protected attribute macros (attr_accessor, attr_writer, attr_reader)
-- Protected instance methods
-- Private attribute macros (attr_accessor, attr_writer, attr_reader)
-- Private instance methods
+- Instance methods
+- Protected methods
+- Private methods
 
 You can configure the following order:
 
 ```yaml
  Layout/ClassStructure:
+     Categories:
+       module_inclusion:
+         - include
+         - prepend
+         - extend
      ExpectedOrder:
-       - module_inclusion
-       - constants
-       - association
-       - public_attribute_macros
-       - public_delegate
-       - macros
-       - public_class_methods
-       - initializer
-       - public_methods
-       - protected_attribute_macros
-       - protected_methods
-       - private_attribute_macros
-       - private_delegate
-       - private_methods
-```
+         - module_inclusion
+         - constants
+         - public_class_methods
+         - initializer
+         - public_methods
+         - protected_methods
+         - private_methods
 
+```
 Instead of putting all literals in the expected order, is also
-possible to group categories of macros. Visibility levels are handled
-automatically.
+possible to group categories of macros.
 
 ```yaml
  Layout/ClassStructure:
@@ -47,17 +39,10 @@ automatically.
        association:
          - has_many
          - has_one
-       attribute_macros:
+       attribute:
          - attr_accessor
          - attr_reader
          - attr_writer
-       macros:
-         - validates
-         - validate
-       module_inclusion:
-         - include
-         - prepend
-         - extend
 ```
 
 ### Example:
@@ -83,14 +68,11 @@ automatically.
       # constants are next
       SOME_CONSTANT = 20
 
-      # afterwards we have public attribute macros
+      # afterwards we have attribute macros
       attr_reader :name
 
       # followed by other macros (if any)
       validates :name
-
-      # then we have public delegate macros
-      delegate :to_s, to: :name
 
       # public class methods are next in line
       def self.some_method
@@ -104,21 +86,13 @@ automatically.
       def some_method
       end
 
-      # protected attribute macros and methods go next
+      # protected and private methods are grouped near the end
       protected
-
-      attr_reader :protected_name
 
       def some_protected_method
       end
 
-      # private attribute macros, delegate macros and methods
-      # are grouped near the end
       private
-
-      attr_reader :private_name
-
-      delegate :some_private_delegate, to: :name
 
       def some_private_method
       end

--- a/config/contents/layout/closing_parenthesis_indentation.md
+++ b/config/contents/layout/closing_parenthesis_indentation.md
@@ -1,4 +1,4 @@
-This cop checks the indentation of hanging closing parentheses in
+This cops checks the indentation of hanging closing parentheses in
 method calls, method definitions, and grouped expressions. A hanging
 closing parenthesis means `)` preceded by a line break.
 

--- a/config/contents/layout/comment_indentation.md
+++ b/config/contents/layout/comment_indentation.md
@@ -1,4 +1,4 @@
-This cop checks the indentation of comments.
+This cops checks the indentation of comments.
 
 ### Example:
     # bad

--- a/config/contents/layout/dot_position.md
+++ b/config/contents/layout/dot_position.md
@@ -3,7 +3,7 @@ This cop checks the . position in multi-line method calls.
 ### Example: EnforcedStyle: leading (default)
     # bad
     something.
-      method
+      mehod
 
     # good
     something
@@ -16,4 +16,4 @@ This cop checks the . position in multi-line method calls.
 
     # good
     something.
-      method
+      mehod

--- a/config/contents/layout/else_alignment.md
+++ b/config/contents/layout/else_alignment.md
@@ -1,4 +1,4 @@
-This cop checks the alignment of else keywords. Normally they should
+This cops checks the alignment of else keywords. Normally they should
 be aligned with an if/unless/while/until/begin/def keyword, but there
 are special cases when they should follow the same rules as the
 alignment of end.

--- a/config/contents/layout/empty_lines.md
+++ b/config/contents/layout/empty_lines.md
@@ -1,4 +1,4 @@
-This cop checks for two or more consecutive blank lines.
+This cops checks for two or more consecutive blank lines.
 
 ### Example:
 

--- a/config/contents/layout/empty_lines_around_arguments.md
+++ b/config/contents/layout/empty_lines_around_arguments.md
@@ -1,4 +1,4 @@
-This cop checks if empty lines exist around the arguments
+This cops checks if empty lines exist around the arguments
 of a method invocation.
 
 ### Example:

--- a/config/contents/layout/empty_lines_around_begin_body.md
+++ b/config/contents/layout/empty_lines_around_begin_body.md
@@ -1,4 +1,4 @@
-This cop checks if empty lines exist around the bodies of begin-end
+This cops checks if empty lines exist around the bodies of begin-end
 blocks.
 
 ### Example:

--- a/config/contents/layout/empty_lines_around_block_body.md
+++ b/config/contents/layout/empty_lines_around_block_body.md
@@ -1,4 +1,4 @@
-This cop checks if empty lines around the bodies of blocks match
+This cops checks if empty lines around the bodies of blocks match
 the configuration.
 
 ### Example: EnforcedStyle: empty_lines

--- a/config/contents/layout/empty_lines_around_class_body.md
+++ b/config/contents/layout/empty_lines_around_class_body.md
@@ -1,4 +1,4 @@
-This cop checks if empty lines around the bodies of classes match
+This cops checks if empty lines around the bodies of classes match
 the configuration.
 
 ### Example: EnforcedStyle: empty_lines

--- a/config/contents/layout/empty_lines_around_exception_handling_keywords.md
+++ b/config/contents/layout/empty_lines_around_exception_handling_keywords.md
@@ -1,4 +1,4 @@
-This cop checks if empty lines exist around the bodies of `begin`
+This cops checks if empty lines exist around the bodies of `begin`
 sections. This cop doesn't check empty lines at `begin` body
 beginning/end and around method definition body.
 `Style/EmptyLinesAroundBeginBody` or `Style/EmptyLinesAroundMethodBody`

--- a/config/contents/layout/empty_lines_around_method_body.md
+++ b/config/contents/layout/empty_lines_around_method_body.md
@@ -1,4 +1,4 @@
-This cop checks if empty lines exist around the bodies of methods.
+This cops checks if empty lines exist around the bodies of methods.
 
 ### Example:
 

--- a/config/contents/layout/empty_lines_around_module_body.md
+++ b/config/contents/layout/empty_lines_around_module_body.md
@@ -1,4 +1,4 @@
-This cop checks if empty lines around the bodies of modules match
+This cops checks if empty lines around the bodies of modules match
 the configuration.
 
 ### Example: EnforcedStyle: empty_lines

--- a/config/contents/layout/extra_spacing.md
+++ b/config/contents/layout/extra_spacing.md
@@ -12,14 +12,3 @@ This cop checks for extra/unnecessary whitespace.
     # bad for any configuration
     set_app("RuboCop")
     website  = "https://github.com/rubocop-hq/rubocop"
-
-    # good only if AllowBeforeTrailingComments is true
-    object.method(arg)  # this is a comment
-
-    # good even if AllowBeforeTrailingComments is false or not set
-    object.method(arg) # this is a comment
-
-    # good with either AllowBeforeTrailingComments or AllowForAlignment
-    object.method(arg)         # this is a comment
-    another_object.method(arg) # this is another comment
-    some_object.method(arg)    # this is some comment

--- a/config/contents/layout/first_parameter_indentation.md
+++ b/config/contents/layout/first_parameter_indentation.md
@@ -1,6 +1,6 @@
 This cop checks the indentation of the first parameter in a method call.
-Parameters after the first one are checked by Style/AlignParameters, not
-by this cop.
+Parameters after the first one are checked by Layout/AlignParameters,
+not by this cop.
 
 ### Example:
 
@@ -9,7 +9,126 @@ by this cop.
     first_param,
     second_param)
 
+    foo = some_method(
+    first_param,
+    second_param)
+
+    foo = some_method(nested_call(
+    nested_first_param),
+    second_param)
+
+    foo = some_method(
+    nested_call(
+    nested_first_param),
+    second_param)
+
+    some_method nested_call(
+    nested_first_param),
+    second_param
+
+### Example: EnforcedStyle: consistent
+    # The first parameter should always be indented one step more than the
+    # preceding line.
+
     # good
     some_method(
       first_param,
     second_param)
+
+    foo = some_method(
+      first_param,
+    second_param)
+
+    foo = some_method(nested_call(
+      nested_first_param),
+    second_param)
+
+    foo = some_method(
+      nested_call(
+        nested_first_param),
+    second_param)
+
+    some_method nested_call(
+      nested_first_param),
+    second_param
+
+### Example: EnforcedStyle: consistent_relative_to_receiver
+    # The first parameter should always be indented one level relative to
+    # the parent that is receiving the parameter
+
+    # good
+    some_method(
+      first_param,
+    second_param)
+
+    foo = some_method(
+            first_param,
+    second_param)
+
+    foo = some_method(nested_call(
+                        nested_first_param),
+    second_param)
+
+    foo = some_method(
+            nested_call(
+              nested_first_param),
+    second_param)
+
+    some_method nested_call(
+                  nested_first_param),
+    second_params
+
+### Example: EnforcedStyle: special_for_inner_method_call
+    # The first parameter should normally be indented one step more than
+    # the preceding line, but if it's a parameter for a method call that
+    # is itself a parameter in a method call, then the inner parameter
+    # should be indented relative to the inner method.
+
+    # good
+    some_method(
+      first_param,
+    second_param)
+
+    foo = some_method(
+      first_param,
+    second_param)
+
+    foo = some_method(nested_call(
+                        nested_first_param),
+    second_param)
+
+    foo = some_method(
+      nested_call(
+        nested_first_param),
+    second_param)
+
+    some_method nested_call(
+                  nested_first_param),
+    second_param
+
+### Example: EnforcedStyle: special_for_inner_method_call_in_parentheses (default)
+    # Same as `special_for_inner_method_call` except that the special rule
+    # only applies if the outer method call encloses its arguments in
+    # parentheses.
+
+    # good
+    some_method(
+      first_param,
+    second_param)
+
+    foo = some_method(
+      first_param,
+    second_param)
+
+    foo = some_method(nested_call(
+                        nested_first_param),
+    second_param)
+
+    foo = some_method(
+      nested_call(
+        nested_first_param),
+    second_param)
+
+    some_method nested_call(
+      nested_first_param),
+    second_param

--- a/config/contents/layout/indent_heredoc.md
+++ b/config/contents/layout/indent_heredoc.md
@@ -1,4 +1,4 @@
-This cop checks the indentation of the here document bodies. The bodies
+This cops checks the indentation of the here document bodies. The bodies
 are indented one step.
 In Ruby 2.3 or newer, squiggly heredocs (`<<~`) should be used. If you
 use the older rubies, you should introduce some library to your project

--- a/config/contents/layout/indentation_consistency.md
+++ b/config/contents/layout/indentation_consistency.md
@@ -1,4 +1,4 @@
-This cop checks for inconsistent indentation.
+This cops checks for inconsistent indentation.
 
 The difference between `rails` and `normal` is that the `rails` style
 prescribes that in classes and modules the `protected` and `private`

--- a/config/contents/layout/indentation_width.md
+++ b/config/contents/layout/indentation_width.md
@@ -1,4 +1,4 @@
-This cop checks for indentation that doesn't use the specified number
+This cops checks for indentation that doesn't use the specified number
 of spaces.
 
 See also the IndentationConsistency cop which is the companion to this

--- a/config/contents/layout/initial_indentation.md
+++ b/config/contents/layout/initial_indentation.md
@@ -1,4 +1,4 @@
-This cop checks for indentation of the first non-blank non-comment
+This cops checks for indentation of the first non-blank non-comment
 line in a file.
 
 ### Example:

--- a/config/contents/layout/multiline_array_brace_layout.md
+++ b/config/contents/layout/multiline_array_brace_layout.md
@@ -1,5 +1,5 @@
 This cop checks that the closing brace in an array literal is either
-on the same line as the last array element or on a new line.
+on the same line as the last array element, or a new line.
 
 When using the `symmetrical` (default) style:
 

--- a/config/contents/layout/space_in_lambda_literal.md
+++ b/config/contents/layout/space_in_lambda_literal.md
@@ -1,5 +1,5 @@
-This cop checks for spaces between `->` and opening parameter
-parenthesis (`(`) in lambda literals.
+This cop checks for spaces between -> and opening parameter
+brace in lambda literals.
 
 ### Example: EnforcedStyle: require_no_space (default)
       # bad

--- a/config/contents/layout/space_inside_array_literal_brackets.md
+++ b/config/contents/layout/space_inside_array_literal_brackets.md
@@ -28,15 +28,10 @@ surrounding space depending on configuration.
 
     # bad
     array = [ a, [ b, c ] ]
-    array = [
-      [ a ],
-      [ b, c ]
-    ]
 
     # good
     array = [ a, [ b, c ]]
-    array = [[ a ],
-      [ b, c ]]
+
 
 ### Example: EnforcedStyleForEmptyBrackets: no_space (default)
     # The `no_space` EnforcedStyleForEmptyBrackets style enforces that

--- a/config/contents/layout/space_inside_hash_literal_braces.md
+++ b/config/contents/layout/space_inside_hash_literal_braces.md
@@ -28,11 +28,10 @@ surrounding space depending on configuration.
 
     # bad
     h = { a: { b: 2 } }
-    foo = { { a: 1 } => { b: { c: 2 } } }
 
     # good
     h = { a: { b: 2 }}
-    foo = {{ a: 1 } => { b: { c: 2 }}}
+
 
 ### Example: EnforcedStyleForEmptyBraces: no_space (default)
     # The `no_space` EnforcedStyleForEmptyBraces style enforces that

--- a/config/contents/lint/deprecated_class_methods.md
+++ b/config/contents/lint/deprecated_class_methods.md
@@ -5,13 +5,9 @@ This cop checks for uses of the deprecated class method usages.
     # bad
 
     File.exists?(some_path)
-    Dir.exists?(some_path)
-    iterator?
 
 ### Example:
 
     # good
 
     File.exist?(some_path)
-    Dir.exist?(some_path)
-    block_given?

--- a/config/contents/lint/ensure_return.md
+++ b/config/contents/lint/ensure_return.md
@@ -1,7 +1,4 @@
 This cop checks for *return* from an *ensure* block.
-Explicit return from an ensure block alters the control flow
-as the return will take precedence over any exception being raised,
-and the exception will be silently thrown away as if it were rescued.
 
 ### Example:
 

--- a/config/contents/lint/missing_cop_enable_directive.md
+++ b/config/contents/lint/missing_cop_enable_directive.md
@@ -1,0 +1,37 @@
+This cop checks that there is an `# rubocop:enable ...` statement
+after a `# rubocop:disable ...` statement. This will prevent leaving
+cop disables on wide ranges of code, that latter contributors to
+a file wouldn't be aware of.
+
+### Example:
+    # Lint/MissingCopEnableDirective:
+    #   MaximumRangeSize: .inf
+
+    # good
+    # rubocop:disable Layout/SpaceAroundOperators
+    x= 0
+    # rubocop:enable Layout/SpaceAroundOperators
+    # y = 1
+    # EOF
+
+    # bad
+    # rubocop:disable Layout/SpaceAroundOperators
+    x= 0
+    # EOF
+
+### Example:
+    # Lint/MissingCopEnableDirective:
+    #   MaximumRangeSize: 2
+
+    # good
+    # rubocop:disable Layout/SpaceAroundOperators
+    x= 0
+    # With the previous, there are 2 lines on which cop is disabled.
+    # rubocop:enable Layout/SpaceAroundOperators
+
+    # bad
+    # rubocop:disable Layout/SpaceAroundOperators
+    x= 0
+    x += 1
+    # Including this, that's 3 lines on which the cop is disabled.
+    # rubocop:enable Layout/SpaceAroundOperators

--- a/config/contents/lint/safe_navigation_chain.md
+++ b/config/contents/lint/safe_navigation_chain.md
@@ -1,6 +1,6 @@
 The safe navigation operator returns nil if the receiver is
-nil. If you chain an ordinary method call after a safe
-navigation operator, it raises NoMethodError. We should use a
+nil.  If you chain an ordinary method call after a safe
+navigation operator, it raises NoMethodError.  We should use a
 safe navigation operator after a safe navigation operator.
 This cop checks for the problem outlined above.
 

--- a/config/contents/lint/shadowed_argument.md
+++ b/config/contents/lint/shadowed_argument.md
@@ -1,12 +1,9 @@
 This cop checks for shadowed arguments.
 
-This cop has `IgnoreImplicitReferences` configuration option.
-It means argument shadowing is used in order to pass parameters
-to zero arity `super` when `IgnoreImplicitReferences` is `true`.
-
 ### Example:
 
     # bad
+
     do_something do |foo|
       foo = 42
       puts foo
@@ -17,7 +14,10 @@ to zero arity `super` when `IgnoreImplicitReferences` is `true`.
       puts foo
     end
 
+### Example:
+
     # good
+
     do_something do |foo|
       foo = foo + 42
       puts foo
@@ -30,30 +30,4 @@ to zero arity `super` when `IgnoreImplicitReferences` is `true`.
 
     def do_something(foo)
       puts foo
-    end
-
-### Example: IgnoreImplicitReferences: false (default)
-
-    # bad
-    def do_something(foo)
-      foo = 42
-      super
-    end
-
-    def do_something(foo)
-      foo = super
-      bar
-    end
-
-### Example: IgnoreImplicitReferences: true
-
-    # good
-    def do_something(foo)
-      foo = 42
-      super
-    end
-
-    def do_something(foo)
-      foo = super
-      bar
     end

--- a/config/contents/lint/syntax.md
+++ b/config/contents/lint/syntax.md
@@ -1,3 +1,0 @@
-This is not actually a cop. It does not inspect anything. It just
-provides methods to repack Parser's diagnostics/errors
-into RuboCop's offenses.

--- a/config/contents/lint/underscore_prefixed_variable_name.md
+++ b/config/contents/lint/underscore_prefixed_variable_name.md
@@ -1,11 +1,7 @@
 This cop checks for underscore-prefixed variables that are actually
 used.
 
-Since block keyword arguments cannot be arbitrarily named at call
-sites, the `AllowKeywordBlockArguments` will allow use of underscore-
-prefixed block keyword arguments.
-
-### Example: AllowKeywordBlockArguments: false (default)
+### Example:
 
     # bad
 
@@ -13,9 +9,7 @@ prefixed block keyword arguments.
       do_something(_num)
     end
 
-    query(:sales) do |_id:, revenue:, cost:|
-      {_id: _id, profit: revenue - cost}
-    end
+### Example:
 
     # good
 
@@ -23,14 +17,10 @@ prefixed block keyword arguments.
       do_something(num)
     end
 
-    [1, 2, 3].each do |_num|
-      do_something # not using `_num`
-    end
-
-### Example: AllowKeywordBlockArguments: true
+### Example:
 
     # good
 
-    query(:sales) do |_id:, revenue:, cost:|
-      {_id: _id, profit: revenue - cost}
+    [1, 2, 3].each do |_num|
+      do_something # not using `_num`
     end

--- a/config/contents/lint/unneeded_cop_disable_directive.md
+++ b/config/contents/lint/unneeded_cop_disable_directive.md
@@ -1,3 +1,19 @@
-# The Lint/UnneededCopDisableDirective cop needs to be disabled so as
-# to be able to provide a (bad) example of an unneeded disable.
-# rubocop:disable Lint/UnneededCopDisableDirective
+This cop detects instances of rubocop:disable comments that can be
+removed without causing any offenses to be reported. It's implemented
+as a cop in that it inherits from the Cop base class and calls
+add_offense. The unusual part of its implementation is that it doesn't
+have any on_* methods or an investigate method. This means that it
+doesn't take part in the investigation phase when the other cops do
+their work. Instead, it waits until it's called in a later stage of the
+execution. The reason it can't be implemented as a normal cop is that
+it depends on the results of all other cops to do its work.
+
+
+### Example:
+    # bad
+    # rubocop:disable Metrics/LineLength
+    x += 1
+    # rubocop:enable Metrics/LineLength
+
+    # good
+    x += 1

--- a/config/contents/lint/unneeded_cop_enable_directive.md
+++ b/config/contents/lint/unneeded_cop_enable_directive.md
@@ -1,3 +1,25 @@
-# The Lint/UnneededCopEnableDirective cop needs to be disabled so as
-# to be able to provide a (bad) example of an unneeded enable.
-# rubocop:disable Lint/UnneededCopEnableDirective
+This cop detects instances of rubocop:enable comments that can be
+removed.
+
+When comment enables all cops at once `rubocop:enable all`
+that cop checks whether any cop was actually enabled.
+### Example:
+    # bad
+    foo = 1
+    # rubocop:enable Metrics/LineLength
+
+    # good
+    foo = 1
+### Example:
+    # bad
+    # rubocop:disable Metrics/LineLength
+    baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarrrrrrrrrrrrr
+    # rubocop:enable Metrics/LineLength
+    baz
+    # rubocop:enable all
+
+    # good
+    # rubocop:disable Metrics/LineLength
+    baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarrrrrrrrrrrrr
+    # rubocop:enable all
+    baz

--- a/config/contents/lint/unneeded_splat_expansion.md
+++ b/config/contents/lint/unneeded_splat_expansion.md
@@ -39,7 +39,7 @@ This cop checks for unneeded usages of splat expansion
     end
 
     case foo
-    when 1, 2, 3
+    when *[1, 2, 3]
       bar
     else
       baz

--- a/config/contents/lint/uri_escape_unescape.md
+++ b/config/contents/lint/uri_escape_unescape.md
@@ -1,9 +1,9 @@
 This cop identifies places where `URI.escape` can be replaced by
-`CGI.escape`, `URI.encode_www_form`, or `URI.encode_www_form_component`
+`CGI.escape`, `URI.encode_www_form` or `URI.encode_www_form_component`
 depending on your specific use case.
 Also this cop identifies places where `URI.unescape` can be replaced by
-`CGI.unescape`, `URI.decode_www_form`,
-or `URI.decode_www_form_component` depending on your specific use case.
+`CGI.unescape`, `URI.decode_www_form` or `URI.decode_www_form_component`
+depending on your specific use case.
 
 ### Example:
     # bad

--- a/config/contents/metrics/abc_size.md
+++ b/config/contents/metrics/abc_size.md
@@ -1,4 +1,3 @@
 This cop checks that the ABC size of methods is not higher than the
 configured maximum. The ABC size is based on assignments, branches
 (method calls), and conditions. See http://c2.com/cgi/wiki?AbcMetric
-and https://en.wikipedia.org/wiki/ABC_Software_Metric.

--- a/config/contents/naming/class_and_module_camel_case.md
+++ b/config/contents/naming/class_and_module_camel_case.md
@@ -1,4 +1,4 @@
-This cop checks for class and module names with
+This cops checks for class and module names with
 an underscore in them.
 
 ### Example:

--- a/config/contents/naming/file_name.md
+++ b/config/contents/naming/file_name.md
@@ -2,11 +2,6 @@ This cop makes sure that Ruby source files have snake_case
 names. Ruby scripts (i.e. source files with a shebang in the
 first line) are ignored.
 
-The cop also ignores `.gemspec` files, because Bundler
-recommends using dashes to separate namespaces in nested gems
-(i.e. `bundler-console` becomes `Bundler::Console`). As such, the
-gemspec is supposed to be named `bundler-console.gemspec`.
-
 ### Example:
     # bad
     lib/layoutManager.rb

--- a/config/contents/naming/memoized_instance_variable_name.md
+++ b/config/contents/naming/memoized_instance_variable_name.md
@@ -1,23 +1,12 @@
 This cop checks for memoized methods whose instance variable name
 does not match the method name.
 
-This cop can be configured with the EnforcedStyleForLeadingUnderscores
-directive. It can be configured to allow for memoized instance variables
-prefixed with an underscore. Prefixing ivars with an underscore is a
-convention that is used to implicitly indicate that an ivar should not
-be set or referencd outside of the memoization method.
-
-### Example: EnforcedStyleForLeadingUnderscores: disallowed (default)
+### Example:
     # bad
     # Method foo is memoized using an instance variable that is
     # not `@foo`. This can cause confusion and bugs.
     def foo
       @something ||= calculate_expensive_thing
-    end
-
-    # good
-    def _foo
-      @foo ||= calculate_expensive_thing
     end
 
     # good
@@ -36,46 +25,4 @@ be set or referencd outside of the memoization method.
     def foo
       helper_variable = something_we_need_to_calculate_foo
       @foo ||= calculate_expensive_thing(helper_variable)
-    end
-
-### Example: EnforcedStyleForLeadingUnderscores: required
-    # bad
-    def foo
-      @something ||= calculate_expensive_thing
-    end
-
-    # bad
-    def foo
-      @foo ||= calculate_expensive_thing
-    end
-
-    # good
-    def foo
-      @_foo ||= calculate_expensive_thing
-    end
-
-    # good
-    def _foo
-      @_foo ||= calculate_expensive_thing
-    end
-
-### Example: EnforcedStyleForLeadingUnderscores :optional
-    # bad
-    def foo
-      @something ||= calculate_expensive_thing
-    end
-
-    # good
-    def foo
-      @foo ||= calculate_expensive_thing
-    end
-
-    # good
-    def foo
-      @_foo ||= calculate_expensive_thing
-    end
-
-    # good
-    def _foo
-      @_foo ||= calculate_expensive_thing
     end

--- a/config/contents/naming/predicate_name.md
+++ b/config/contents/naming/predicate_name.md
@@ -2,9 +2,6 @@ This cop makes sure that predicates are named properly.
 
 ### Example:
     # bad
-    def is_even(value)
-    end
-
     def is_even?(value)
     end
 
@@ -13,9 +10,6 @@ This cop makes sure that predicates are named properly.
     end
 
     # bad
-    def has_value
-    end
-
     def has_value?
     end
 

--- a/config/contents/naming/variable_number.md
+++ b/config/contents/naming/variable_number.md
@@ -1,5 +1,5 @@
 This cop makes sure that all numbered variables use the
-configured style, snake_case, normalcase, or non_integer,
+configured style, snake_case, normalcase or non_integer,
 for their numbering.
 
 ### Example: EnforcedStyle: snake_case

--- a/config/contents/performance/end_with.md
+++ b/config/contents/performance/end_with.md
@@ -3,6 +3,7 @@ would suffice.
 
 ### Example:
     # bad
+    'abc'.match?(/bc\Z/)
     'abc' =~ /bc\Z/
     'abc'.match(/bc\Z/)
 

--- a/config/contents/performance/fixed_size.md
+++ b/config/contents/performance/fixed_size.md
@@ -1,0 +1,41 @@
+Do not compute the size of statically sized objects.
+
+### Example:
+    # String methods
+    # bad
+    'foo'.size
+    %q[bar].count
+    %(qux).length
+
+    # Symbol methods
+    # bad
+    :fred.size
+    :'baz'.length
+
+    # Array methods
+    # bad
+    [1, 2, thud].count
+    %W(1, 2, bar).size
+
+    # Hash methods
+    # bad
+    { a: corge, b: grault }.length
+
+    # good
+    foo.size
+    bar.count
+    qux.length
+
+    # good
+    :"#{fred}".size
+    CONST = :baz.length
+
+    # good
+    [1, 2, *thud].count
+    garply = [1, 2, 3]
+    garly.size
+
+    # good
+    { a: corge, **grault }.length
+    waldo = { a: corge, b: grault }
+    waldo.size

--- a/config/contents/performance/inefficient_hash_search.md
+++ b/config/contents/performance/inefficient_hash_search.md
@@ -1,0 +1,32 @@
+This cop checks for inefficient searching of keys and values within
+hashes.
+
+`Hash#keys.include?` is less efficient than `Hash#key?` because
+the former allocates a new array and then performs an O(n) search
+through that array, while `Hash#key?` does not allocate any array and
+performs a faster O(1) search for the key.
+
+`Hash#values.include?` is less efficient than `Hash#value?`. While they
+both perform an O(n) search through all of the values, calling `values`
+allocates a new array while using `value?` does not.
+
+### Example:
+    # bad
+    { a: 1, b: 2 }.keys.include?(:a)
+    { a: 1, b: 2 }.keys.include?(:z)
+    h = { a: 1, b: 2 }; h.keys.include?(100)
+
+    # good
+    { a: 1, b: 2 }.key?(:a)
+    { a: 1, b: 2 }.has_key?(:z)
+    h = { a: 1, b: 2 }; h.key?(100)
+
+    # bad
+    { a: 1, b: 2 }.values.include?(2)
+    { a: 1, b: 2 }.values.include?('garbage')
+    h = { a: 1, b: 2 }; h.values.include?(nil)
+
+    # good
+    { a: 1, b: 2 }.value?(2)
+    { a: 1, b: 2 }.has_value?('garbage')
+    h = { a: 1, b: 2 }; h.value?(nil)

--- a/config/contents/performance/regexp_match.md
+++ b/config/contents/performance/regexp_match.md
@@ -14,6 +14,13 @@ So, when `MatchData` is not used, use `match?` instead of `match`.
 
     # bad
     def foo
+      if x !~ /re/
+        do_something
+      end
+    end
+
+    # bad
+    def foo
       if x.match(/re/)
         do_something
       end
@@ -29,6 +36,13 @@ So, when `MatchData` is not used, use `match?` instead of `match`.
     # good
     def foo
       if x.match?(/re/)
+        do_something
+      end
+    end
+
+    # good
+    def foo
+      if !x.match?(/re/)
         do_something
       end
     end

--- a/config/contents/performance/start_with.md
+++ b/config/contents/performance/start_with.md
@@ -3,6 +3,7 @@ This cop identifies unnecessary use of a regex where
 
 ### Example:
     # bad
+    'abc'.match?(/\Aab/)
     'abc' =~ /\Aab/
     'abc'.match(/\Aab/)
 

--- a/config/contents/performance/unneeded_sort.md
+++ b/config/contents/performance/unneeded_sort.md
@@ -1,0 +1,45 @@
+This cop is used to identify instances of sorting and then
+taking only the first or last element. The same behavior can
+be accomplished without a relatively expensive sort by using
+`Enumerable#min` instead of sorting and taking the first
+element and `Enumerable#max` instead of sorting and taking the
+last element. Similarly, `Enumerable#min_by` and
+`Enumerable#max_by` can replace `Enumerable#sort_by` calls
+after which only the first or last element is used.
+
+### Example:
+    # bad
+    [2, 1, 3].sort.first
+    [2, 1, 3].sort[0]
+    [2, 1, 3].sort.at(0)
+    [2, 1, 3].sort.slice(0)
+
+    # good
+    [2, 1, 3].min
+
+    # bad
+    [2, 1, 3].sort.last
+    [2, 1, 3].sort[-1]
+    [2, 1, 3].sort.at(-1)
+    [2, 1, 3].sort.slice(-1)
+
+    # good
+    [2, 1, 3].max
+
+    # bad
+    arr.sort_by(&:foo).first
+    arr.sort_by(&:foo)[0]
+    arr.sort_by(&:foo).at(0)
+    arr.sort_by(&:foo).slice(0)
+
+    # good
+    arr.min_by(&:foo)
+
+    # bad
+    arr.sort_by(&:foo).last
+    arr.sort_by(&:foo)[-1]
+    arr.sort_by(&:foo).at(-1)
+    arr.sort_by(&:foo).slice(-1)
+
+    # good
+    arr.max_by(&:foo)

--- a/config/contents/rails/blank.md
+++ b/config/contents/rails/blank.md
@@ -1,11 +1,6 @@
 This cop checks for code that can be written with simpler conditionals
 using `Object#blank?` defined by Active Support.
 
-Interaction with `Style/UnlessElse`:
-The configuration of `NotPresent` will not produce an offense in the
-context of `unless else` if `Style/UnlessElse` is inabled. This is
-to prevent interference between the auto-correction of the two cops.
-
 ### Example: NilOrEmpty: true (default)
     # Converts usages of `nil? || empty?` to `blank?`
 
@@ -42,9 +37,4 @@ to prevent interference between the auto-correction of the two cops.
     # good
     if foo.blank?
       something
-    end
-
-    # good
-    def blank?
-      !present?
     end

--- a/config/contents/rails/bulk_change_table.md
+++ b/config/contents/rails/bulk_change_table.md
@@ -1,8 +1,8 @@
 This Cop checks whether alter queries are combinable.
 If combinable queries are detected, it suggests to you
 to use `change_table` with `bulk: true` instead.
-This option causes the migration to generate a single
-ALTER TABLE statement combining multiple column alterations.
+When use this method, make combinable alter queries
+a bulk alter query.
 
 The `bulk` option is only supported on the MySQL and
 the PostgreSQL (5.2 later) adapter; thus it will
@@ -58,5 +58,5 @@ this Cop ignores offenses.
       end
     end
 
-@see https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-change_table
-@see https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/Table.html
+@see http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-change_table
+@see http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/Table.html

--- a/config/contents/rails/date.md
+++ b/config/contents/rails/date.md
@@ -1,19 +1,19 @@
 This cop checks for the correct use of Date methods,
 such as Date.today, Date.current etc.
 
-Using `Date.today` is dangerous, because it doesn't know anything about
-Rails time zone. You must use `Time.zone.today` instead.
+Using Date.today is dangerous, because it doesn't know anything about
+Rails time zone. You must use Time.zone.today instead.
 
-The cop also reports warnings when you are using `to_time` method,
+The cop also reports warnings when you are using 'to_time' method,
 because it doesn't know about Rails time zone either.
 
 Two styles are supported for this cop. When EnforcedStyle is 'strict'
-then the Date methods `today`, `current`, `yesterday`, and `tomorrow`
-are prohibited and the usage of both `to_time`
-and 'to_time_in_current_zone' are reported as warning.
+then the Date methods (today, current, yesterday, tomorrow)
+are prohibited and the usage of both 'to_time'
+and 'to_time_in_current_zone' is reported as warning.
 
-When EnforcedStyle is 'flexible' then only `Date.today` is prohibited
-and only `to_time` is reported as warning.
+When EnforcedStyle is 'flexible' then only 'Date.today' is prohibited
+and only 'to_time' is reported as warning.
 
 ### Example: EnforcedStyle: strict
     # bad
@@ -21,6 +21,7 @@ and only `to_time` is reported as warning.
     Date.yesterday
     Date.today
     date.to_time
+    date.to_time_in_current_zone
 
     # good
     Time.zone.today
@@ -36,4 +37,4 @@ and only `to_time` is reported as warning.
     Time.zone.today - 1.day
     Date.current
     Date.yesterday
-    date.in_time_zone
+    date.to_time_in_current_zone

--- a/config/contents/rails/delegate.md
+++ b/config/contents/rails/delegate.md
@@ -30,7 +30,7 @@ When set to `false`, this case is legal.
       foo.bar
     end
 
-### Example: EnforceForPrefixed: true (default)
+    # EnforceForPrefixed: true
     # bad
     def foo_bar
       foo.bar
@@ -39,7 +39,7 @@ When set to `false`, this case is legal.
     # good
     delegate :bar, to: :foo, prefix: true
 
-### Example: EnforceForPrefixed: false
+    # EnforceForPrefixed: false
     # good
     def foo_bar
       foo.bar

--- a/config/contents/rails/exit.md
+++ b/config/contents/rails/exit.md
@@ -1,12 +1,12 @@
-This cop enforces that `exit` calls are not used within a rails app.
-Valid options are instead to raise an error, break, return, or some
+This cop enforces that 'exit' calls are not used within a rails app.
+Valid options are instead to raise an error, break, return or some
 other form of stopping execution of current request.
 
-There are two obvious cases where `exit` is particularly harmful:
+There are two obvious cases where 'exit' is particularly harmful:
 
-- Usage in library code for your application. Even though Rails will
-rescue from a `SystemExit` and continue on, unit testing that library
-code will result in specs exiting (potentially silently if `exit(0)`
+- Usage in library code for your application. Even though rails will
+rescue from a SystemExit and continue on, unit testing that library
+code will result in specs exiting (potentially silently if exit(0)
 is used.)
 - Usage in application code outside of the web process could result in
 the program exiting, which could result in the code failing to run and

--- a/config/contents/rails/http_positional_arguments.md
+++ b/config/contents/rails/http_positional_arguments.md
@@ -1,6 +1,6 @@
 This cop is used to identify usages of http methods like `get`, `post`,
 `put`, `patch` without the usage of keyword arguments in your tests and
-change them to use keyword args. This cop only applies to Rails >= 5.
+change them to use keyword args.  This cop only applies to Rails >= 5 .
 If you are running Rails < 5 you should disable the
 Rails/HttpPositionalArguments cop or set your TargetRailsVersion in your
 .rubocop.yml file to 4.0, etc.

--- a/config/contents/rails/inverse_of.md
+++ b/config/contents/rails/inverse_of.md
@@ -33,8 +33,9 @@ inverse automatically, and is not considered a valid value for this.
     # good
     class Blog < ApplicationRecord
       has_many(:posts,
-               -> { order(published_at: :desc) },
-               inverse_of: :blog)
+        -> { order(published_at: :desc) },
+        inverse_of: :blog
+      )
     end
 
     class Post < ApplicationRecord
@@ -56,8 +57,9 @@ inverse automatically, and is not considered a valid value for this.
     # When you don't want to use the inverse association.
     class Blog < ApplicationRecord
       has_many(:posts,
-               -> { order(published_at: :desc) },
-               inverse_of: false)
+        -> { order(published_at: :desc) },
+        inverse_of: false
+      )
     end
 
 ### Example:
@@ -121,5 +123,5 @@ inverse automatically, and is not considered a valid value for this.
       has_many :physicians, through: :appointments
     end
 
-@see https://guides.rubyonrails.org/association_basics.html#bi-directional-associations
-@see https://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#module-ActiveRecord::Associations::ClassMethods-label-Setting+Inverses
+@see http://guides.rubyonrails.org/association_basics.html#bi-directional-associations
+@see http://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#module-ActiveRecord::Associations::ClassMethods-label-Setting+Inverses

--- a/config/contents/rails/lexically_scoped_action_filter.md
+++ b/config/contents/rails/lexically_scoped_action_filter.md
@@ -1,13 +1,10 @@
-This cop checks that methods specified in the filter's `only` or
-`except` options are defined within the same class or module.
+This cop checks that methods specified in the filter's `only`
+or `except` options are explicitly defined in the class or module.
 
-You can technically specify methods of superclass or methods added by
-mixins on the filter, but these can confuse developers. If you specify
-methods that are defined in other classes or modules, you should
-define the filter in that class or module.
-
-If you rely on behaviour defined in the superclass actions, you must
-remember to invoke `super` in the subclass actions.
+You can specify methods of superclass or methods added by mixins
+on the filter, but these confuse developers. If you specify methods
+where are defined on another classes or modules, you should define
+the filter in that class or module.
 
 ### Example:
     # bad
@@ -52,28 +49,5 @@ remember to invoke `super` in the subclass actions.
 
       def foo
         # something
-      end
-    end
-
-### Example:
-    class ContentController < ApplicationController
-      def update
-        @content.update(content_attributes)
-      end
-    end
-
-    class ArticlesController < ContentController
-      before_action :load_article, only: [:update]
-
-      # the cop requires this method, but it relies on behaviour defined
-      # in the superclass, so needs to invoke `super`
-      def update
-        super
-      end
-
-      private
-
-      def load_article
-        @content = Article.find(params[:article_id])
       end
     end

--- a/config/contents/rails/output_safety.md
+++ b/config/contents/rails/output_safety.md
@@ -1,7 +1,7 @@
-This cop checks for the use of output safety calls like `html_safe`,
-`raw`, and `safe_concat`. These methods do not escape content. They
+This cop checks for the use of output safety calls like html_safe,
+raw, and safe_concat. These methods do not escape content. They
 simply return a SafeBuffer containing the content as is. Instead,
-use `safe_join` to join content and escape it and concat to
+use safe_join to join content and escape it and concat to
 concatenate content and escape it, ensuring its safety.
 
 ### Example:

--- a/config/contents/rails/present.md
+++ b/config/contents/rails/present.md
@@ -1,10 +1,7 @@
 This cop checks for code that can be written with simpler conditionals
 using `Object#present?` defined by Active Support.
 
-Interaction with `Style/UnlessElse`:
-The configuration of `NotBlank` will not produce an offense in the
-context of `unless else` if `Style/UnlessElse` is inabled. This is
-to prevent interference between the auto-correction of the two cops.
+simpler conditionals.
 
 ### Example: NotNilAndNotEmpty: true (default)
     # Converts usages of `!nil? && !empty?` to `present?`

--- a/config/contents/rails/read_write_attribute.md
+++ b/config/contents/rails/read_write_attribute.md
@@ -1,10 +1,9 @@
-This cop checks for the use of the `read_attribute` or `write_attribute`
-methods and recommends square brackets instead.
+This cop checks for the use of the read_attribute or write_attribute
+methods, and recommends square brackets instead.
 
 If an attribute is missing from the instance (for example, when
-initialized by a partial `select`) then `read_attribute`
-will return nil, but square brackets will raise
-an `ActiveModel::MissingAttributeError`.
+initialized by a partial `select`) then read_attribute will return nil,
+but square brackets will raise an ActiveModel::MissingAttributeError.
 
 Explicitly raising an error in this situation is preferable, and that
 is why rubocop recommends using square brackets.

--- a/config/contents/rails/reversible_migration.md
+++ b/config/contents/rails/reversible_migration.md
@@ -119,4 +119,4 @@ reversible.
       end
     end
 
-@see https://api.rubyonrails.org/classes/ActiveRecord/Migration/CommandRecorder.html
+@see http://api.rubyonrails.org/classes/ActiveRecord/Migration/CommandRecorder.html

--- a/config/contents/rails/save_bang.md
+++ b/config/contents/rails/save_bang.md
@@ -2,21 +2,12 @@ This cop identifies possible cases where Active Record save! or related
 should be used instead of save because the model might have failed to
 save and an exception is better than unhandled failure.
 
-This will allow:
-- update or save calls, assigned to a variable,
-    or used as a condition in an if/unless/case statement.
-- create calls, assigned to a variable that then has a
-    call to `persisted?`.
-- calls if the result is explicitly returned from methods and blocks,
-    or provided as arguments.
-- calls whose signature doesn't look like an ActiveRecord
-    persistence method.
-
-By default it will also allow implicit returns from methods and blocks.
-that behavior can be turned off with `AllowImplicitReturn: false`.
-
-You can permit receivers that are giving false positives with
-`AllowedReceivers: []`
+This will ignore calls that return a boolean for success if the result
+is assigned to a variable or used as the condition in an if/unless
+statement.  It will also ignore calls that return a model assigned to a
+variable that has a call to `persisted?`. Finally, it will ignore any
+call with more than 2 arguments as that is likely not an Active Record
+call or a Model.update(id, attributes) call.
 
 ### Example:
 
@@ -39,54 +30,3 @@ You can permit receivers that are giving false positives with
     unless user.persisted?
       # ...
     end
-
-    def save_user
-      return user.save
-    end
-
-### Example: AllowImplicitReturn: true (default)
-
-    # good
-    users.each { |u| u.save }
-
-    def save_user
-      user.save
-    end
-
-### Example: AllowImplicitReturn: false
-
-    # bad
-    users.each { |u| u.save }
-    def save_user
-      user.save
-    end
-
-    # good
-    users.each { |u| u.save! }
-
-    def save_user
-      user.save!
-    end
-
-    def save_user
-      return user.save
-    end
-
-### Example: AllowedReceivers: ['merchant.customers', 'Service::Mailer']
-
-    # bad
-    merchant.create
-    customers.builder.save
-    Mailer.create
-
-    module Service::Mailer
-      self.create
-    end
-
-    # good
-    merchant.customers.create
-    MerchantService.merchant.customers.destroy
-    Service::Mailer.update(message: 'Message')
-    ::Service::Mailer.update
-    Services::Service::Mailer.update(message: 'Message')
-    Service::Mailer::update

--- a/config/contents/rails/skips_model_validations.md
+++ b/config/contents/rails/skips_model_validations.md
@@ -1,8 +1,6 @@
 This cop checks for the use of methods which skip
 validations which are listed in
-https://guides.rubyonrails.org/active_record_validations.html#skipping-validations
-
-Methods may be ignored from this rule by configuring a `Whitelist`.
+http://guides.rubyonrails.org/active_record_validations.html#skipping-validations
 
 ### Example:
     # bad
@@ -20,12 +18,3 @@ Methods may be ignored from this rule by configuring a `Whitelist`.
     # good
     user.update(website: 'example.com')
     FileUtils.touch('file')
-
-### Example: Whitelist: ["touch"]
-    # bad
-    DiscussionBoard.decrement_counter(:post_count, 5)
-    DiscussionBoard.increment_counter(:post_count, 5)
-    person.toggle :active
-
-    # good
-    user.touch

--- a/config/contents/rails/validation.md
+++ b/config/contents/rails/validation.md
@@ -10,7 +10,6 @@ This cop checks for the use of old-style attribute validation macros.
     validates_length_of :foo
     validates_numericality_of :foo
     validates_presence_of :foo
-    validates_absence_of :foo
     validates_size_of :foo
     validates_uniqueness_of :foo
 
@@ -23,6 +22,5 @@ This cop checks for the use of old-style attribute validation macros.
     validates :foo, length: true
     validates :foo, numericality: true
     validates :foo, presence: true
-    validates :foo, absence: true
     validates :foo, size: true
     validates :foo, uniqueness: true

--- a/config/contents/security/json_load.md
+++ b/config/contents/security/json_load.md
@@ -10,9 +10,9 @@ option, like `JSON.parse('false', quirks_mode: true)`.
 Other similar issues may apply.
 
 ### Example:
-    # bad
+    # always offense
     JSON.load("{}")
     JSON.restore("{}")
 
-    # good
+    # no offense
     JSON.parse("{}")

--- a/config/contents/security/open.md
+++ b/config/contents/security/open.md
@@ -1,10 +1,9 @@
 This cop checks for the use of `Kernel#open`.
-
 `Kernel#open` enables not only file access but also process invocation
-by prefixing a pipe symbol (e.g., `open("| ls")`). So, it may lead to
+by prefixing a pipe symbol (e.g., `open("| ls")`).  So, it may lead to
 a serious security risk by using variable input to the argument of
-`Kernel#open`. It would be better to use `File.open`, `IO.popen` or
-`URI#open` explicitly.
+`Kernel#open`.  It would be better to use `File.open` or `IO.popen`
+explicitly.
 
 ### Example:
     # bad
@@ -13,4 +12,3 @@ a serious security risk by using variable input to the argument of
     # good
     File.open(something)
     IO.popen(something)
-    URI.parse(something).open

--- a/config/contents/style/and_or.md
+++ b/config/contents/style/and_or.md
@@ -1,5 +1,5 @@
 This cop checks for uses of `and` and `or`, and suggests using `&&` and
-`||` instead. It can be configured to check only in conditions or in
+`|| instead`. It can be configured to check only in conditions, or in
 all contexts.
 
 ### Example: EnforcedStyle: always (default)

--- a/config/contents/style/begin_block.md
+++ b/config/contents/style/begin_block.md
@@ -1,6 +1,0 @@
-
-This cop checks for BEGIN blocks.
-
-### Example:
-    # bad
-    BEGIN { test }

--- a/config/contents/style/block_delimiters.md
+++ b/config/contents/style/block_delimiters.md
@@ -55,30 +55,6 @@ multi-line blocks.
       x
     }.inspect
 
-    # The AllowBracesOnProceduralOneLiners option is ignored unless the
-    # EnforcedStyle is set to `semantic`. If so:
-
-    # If the AllowBracesOnProceduralOneLiners option is unspecified, or
-    # set to `false` or any other falsey value, then semantic purity is
-    # maintained, so one-line procedural blocks must use do-end, not
-    # braces.
-
-    # bad
-    collection.each { |element| puts element }
-
-    # good
-    collection.each do |element| puts element end
-
-    # If the AllowBracesOnProceduralOneLiners option is set to `true`, or
-    # any other truthy value, then one-line procedural blocks may use
-    # either style. (There is no setting for requiring braces on them.)
-
-    # good
-    collection.each { |element| puts element }
-
-    # also good
-    collection.each do |element| puts element end
-
 ### Example: EnforcedStyle: braces_for_chaining
     # bad
     words.each do |word|
@@ -89,14 +65,3 @@ multi-line blocks.
     words.each { |word|
       word.flip.flop
     }.join("-")
-
-### Example: EnforcedStyle: always_braces
-    # bad
-    words.each do |word|
-      word.flip.flop
-    end
-
-    # good
-    words.each { |word|
-      word.flip.flop
-    }

--- a/config/contents/style/class_vars.md
+++ b/config/contents/style/class_vars.md
@@ -21,6 +21,6 @@ use a class instance variable instead.
 
     class A
       def test
-        @@test # you can access class variable without offense
+        @@test # you can access class variable without offence
       end
     end

--- a/config/contents/style/collection_methods.md
+++ b/config/contents/style/collection_methods.md
@@ -4,28 +4,3 @@ from the Enumerable module.
 Unfortunately we cannot actually know if a method is from
 Enumerable or not (static analysis limitation), so this cop
 can yield some false positives.
-
-You can customize the mapping from undesired method to desired method.
-
-e.g. to use `detect` over `find`:
-
-    Style/CollectionMethods:
-      PreferredMethods:
-        find: detect
-
-The default mapping for `PreferredMethods` behaves as follows.
-
-### Example:
-    # bad
-    items.collect
-    items.collect!
-    items.inject
-    items.detect
-    items.find_all
-
-    # good
-    items.map
-    items.map!
-    items.reduce
-    items.find
-    items.select

--- a/config/contents/style/commented_keyword.md
+++ b/config/contents/style/commented_keyword.md
@@ -1,8 +1,8 @@
 This cop checks for comments put on the same line as some keywords.
 These keywords are: `begin`, `class`, `def`, `end`, `module`.
 
-Note that some comments (`:nodoc:`, `:yields:, and `rubocop:disable`)
-are allowed.
+Note that some comments (such as `:nodoc:` and `rubocop:disable`) are
+allowed.
 
 ### Example:
     # bad

--- a/config/contents/style/conditional_assignment.md
+++ b/config/contents/style/conditional_assignment.md
@@ -1,0 +1,93 @@
+Check for `if` and `case` statements where each branch is used for
+assignment to the same variable when using the return of the
+condition can be used instead.
+
+### Example: EnforcedStyle: assign_to_condition (default)
+    # bad
+    if foo
+      bar = 1
+    else
+      bar = 2
+    end
+
+    case foo
+    when 'a'
+      bar += 1
+    else
+      bar += 2
+    end
+
+    if foo
+      some_method
+      bar = 1
+    else
+      some_other_method
+      bar = 2
+    end
+
+    # good
+    bar = if foo
+            1
+          else
+            2
+          end
+
+    bar += case foo
+           when 'a'
+             1
+           else
+             2
+           end
+
+    bar << if foo
+             some_method
+             1
+           else
+             some_other_method
+             2
+           end
+
+### Example: EnforcedStyle: assign_inside_condition
+    # bad
+    bar = if foo
+            1
+          else
+            2
+          end
+
+    bar += case foo
+           when 'a'
+             1
+           else
+             2
+           end
+
+    bar << if foo
+             some_method
+             1
+           else
+             some_other_method
+             2
+           end
+
+    # good
+    if foo
+      bar = 1
+    else
+      bar = 2
+    end
+
+    case foo
+    when 'a'
+      bar += 1
+    else
+      bar += 2
+    end
+
+    if foo
+      some_method
+      bar = 1
+    else
+      some_other_method
+      bar = 2
+    end

--- a/config/contents/style/copyright.md
+++ b/config/contents/style/copyright.md
@@ -1,11 +1,11 @@
 Check that a copyright notice was given in each source file.
 
 The default regexp for an acceptable copyright notice can be found in
-config/default.yml. The default can be changed as follows:
+config/default.yml.  The default can be changed as follows:
 
       Style/Copyright:
         Notice: '^Copyright (\(c\) )?2\d{3} Acme Inc'
 
-This regex string is treated as an unanchored regex. For each file
+This regex string is treated as an unanchored regex.  For each file
 that RuboCop scans, a comment that matches this regex must be found or
 an offense is reported.

--- a/config/contents/style/date_time.md
+++ b/config/contents/style/date_time.md
@@ -1,8 +1,5 @@
-This cop checks for consistent usage of the `DateTime` class over the
-`Time` class. This cop is disabled by default since these classes,
-although highly overlapping, have particularities that make them not
-replaceable in certain situations when dealing with multiple timezones
-and/or DST.
+This cop checks for uses of `DateTime` that should be replaced by
+`Date` or `Time`.
 
 ### Example:
 
@@ -15,24 +12,8 @@ and/or DST.
     # bad - uses `DateTime` for modern date
     DateTime.iso8601('2016-06-29')
 
-    # good - uses `Time` for modern date
-    Time.iso8601('2016-06-29')
+    # good - uses `Date` for modern date
+    Date.iso8601('2016-06-29')
 
     # good - uses `DateTime` with start argument for historical date
     DateTime.iso8601('1751-04-23', Date::ENGLAND)
-
-### Example: AllowCoercion: false (default)
-
-    # bad - coerces to `DateTime`
-    something.to_datetime
-
-    # good - coerces to `Time`
-    something.to_time
-
-### Example: AllowCoercion: true
-
-    # good
-    something.to_datetime
-
-    # good
-    something.to_time

--- a/config/contents/style/empty_literal.md
+++ b/config/contents/style/empty_literal.md
@@ -1,5 +1,5 @@
 This cop checks for the use of a method, the result of which
-would be a literal, like an empty array, hash, or string.
+would be a literal, like an empty array, hash or string.
 
 ### Example:
     # bad

--- a/config/contents/style/encoding.md
+++ b/config/contents/style/encoding.md
@@ -1,6 +1,0 @@
-This cop checks ensures source files have no utf-8 encoding comments.
-### Example:
-    # bad
-    # encoding: UTF-8
-    # coding: UTF-8
-    # -*- coding: UTF-8 -*-

--- a/config/contents/style/end_block.md
+++ b/config/contents/style/end_block.md
@@ -1,8 +1,0 @@
-This cop checks for END blocks.
-
-### Example:
-    # bad
-    END { puts 'Goodbye!' }
-
-    # good
-    at_exit { puts 'Goodbye!' }

--- a/config/contents/style/even_odd.md
+++ b/config/contents/style/even_odd.md
@@ -1,5 +1,5 @@
-This cop checks for places where `Integer#even?` or `Integer#odd?`
-can be used.
+This cop checks for places where Integer#even? or Integer#odd?
+should have been used.
 
 ### Example:
 

--- a/config/contents/style/for.md
+++ b/config/contents/style/for.md
@@ -1,7 +1,7 @@
-This cop looks for uses of the `for` keyword or `each` method. The
+This cop looks for uses of the *for* keyword, or *each* method. The
 preferred alternative is set in the EnforcedStyle configuration
-parameter. An `each` call with a block on a single line is always
-allowed.
+parameter. An *each* call with a block on a single line is always
+allowed, however.
 
 ### Example: EnforcedStyle: each (default)
     # bad

--- a/config/contents/style/frozen_string_literal_comment.md
+++ b/config/contents/style/frozen_string_literal_comment.md
@@ -1,7 +1,7 @@
-This cop is designed to help upgrade to after Ruby 3.0. It will add the
+This cop is designed to help upgrade to Ruby 3.0. It will add the
 comment `# frozen_string_literal: true` to the top of files to
 enable frozen string literals. Frozen string literals may be default
-after Ruby 3.0. The comment will be added below a shebang and encoding
+in Ruby 3.0. The comment will be added below a shebang and encoding
 comment. The frozen string literal comment is only valid in Ruby 2.3+.
 
 ### Example: EnforcedStyle: when_needed (default)

--- a/config/contents/style/global_vars.md
+++ b/config/contents/style/global_vars.md
@@ -1,4 +1,4 @@
-This cop looks for uses of global variables.
+This cops looks for uses of global variables.
 It does not report offenses for built-in global variables.
 Built-in global variables are allowed by default. Additionally
 users can allow additional variables via the AllowedVariables option.

--- a/config/contents/style/if_unless_modifier.md
+++ b/config/contents/style/if_unless_modifier.md
@@ -1,7 +1,6 @@
 Checks for if and unless statements that would fit on one line
 if written as a modifier if/unless. The maximum line length is
-configured in the `Metrics/LineLength` cop. The tab size is configured
-in the `IndentationWidth` of the `Layout/Tab` cop.
+configured in the `Metrics/LineLength` cop.
 
 ### Example:
     # bad

--- a/config/contents/style/method_call_with_args_parentheses.md
+++ b/config/contents/style/method_call_with_args_parentheses.md
@@ -1,0 +1,36 @@
+This cop checks presence of parentheses in method calls containing
+parameters. By default, macro methods are ignored. Additional methods
+can be added to the `IgnoredMethods` list.
+
+### Example:
+
+    # bad
+    array.delete e
+
+    # good
+    array.delete(e)
+
+    # good
+    # Operators don't need parens
+    foo == bar
+
+    # good
+    # Setter methods don't need parens
+    foo.bar = baz
+
+    # okay with `puts` listed in `IgnoredMethods`
+    puts 'test'
+
+    # IgnoreMacros: true (default)
+
+    # good
+    class Foo
+      bar :baz
+    end
+
+    # IgnoreMacros: false
+
+    # bad
+    class Foo
+      bar :baz
+    end

--- a/config/contents/style/method_def_parentheses.md
+++ b/config/contents/style/method_def_parentheses.md
@@ -1,4 +1,4 @@
-This cop checks for parentheses around the arguments in method
+This cops checks for parentheses around the arguments in method
 definitions. Both instance and class/singleton methods are checked.
 
 ### Example: EnforcedStyle: require_parentheses (default)
@@ -55,8 +55,8 @@ definitions. Both instance and class/singleton methods are checked.
 
 ### Example: EnforcedStyle: require_no_parentheses_except_multiline
     # The `require_no_parentheses_except_multiline` style prefers no
-    # parentheses when method definition arguments fit on single line,
-    # but prefers parentheses when arguments span multiple lines.
+    # parantheses when method definition arguments fit on single line,
+    # but prefers parantheses when arguments span multiple lines.
 
     # bad
     def bar(num1, num2)

--- a/config/contents/style/module_function.md
+++ b/config/contents/style/module_function.md
@@ -1,4 +1,4 @@
-This cop checks for use of `extend self` or `module_function` in a
+This cops checks for use of `extend self` or `module_function` in a
 module.
 
 Supported styles are: module_function, extend_self.
@@ -16,18 +16,6 @@ Supported styles are: module_function, extend_self.
       # ...
     end
 
-In case there are private methods, the cop won't be activated.
-Otherwise, it forces to change the flow of the default code.
-
-### Example: EnforcedStyle: module_function (default)
-    # good
-    module Test
-      extend self
-      # ...
-      private
-      # ...
-    end
-
 ### Example: EnforcedStyle: extend_self
     # bad
     module Test
@@ -41,5 +29,5 @@ Otherwise, it forces to change the flow of the default code.
       # ...
     end
 
-These offenses are not safe to auto-correct since there are different
+These offenses are not auto-corrected since there are different
 implications to each approach.

--- a/config/contents/style/mutable_constant.md
+++ b/config/contents/style/mutable_constant.md
@@ -1,15 +1,7 @@
 This cop checks whether some constant value isn't a
 mutable literal (e.g. array or hash).
 
-Strict mode can be used to freeze all constants, rather than
-just literals.
-Strict mode is considered an experimental feature. It has not been
-updated with an exhaustive list of all methods that will produce
-frozen objects so there is a decent chance of getting some false
-positives. Luckily, there is no harm in freezing an already
-frozen object.
-
-### Example: EnforcedStyle: literals (default)
+### Example:
     # bad
     CONST = [1, 2, 3]
 
@@ -18,30 +10,5 @@ frozen object.
 
     # good
     CONST = <<~TESTING.freeze
-      This is a heredoc
+    This is a heredoc
     TESTING
-
-    # good
-    CONST = Something.new
-
-
-### Example: EnforcedStyle: strict
-    # bad
-    CONST = Something.new
-
-    # bad
-    CONST = Struct.new do
-      def foo
-        puts 1
-      end
-    end
-
-    # good
-    CONST = Something.new.freeze
-
-    # good
-    CONST = Struct.new do
-      def foo
-        puts 1
-      end
-    end.freeze

--- a/config/contents/style/nil_comparison.md
+++ b/config/contents/style/nil_comparison.md
@@ -1,9 +1,6 @@
-This cop checks for comparison of something with nil using `==` and
-`nil?`.
+This cop checks for comparison of something with nil using ==.
 
-Supported styles are: predicate, comparison.
-
-### Example: EnforcedStyle: predicate (default)
+### Example:
 
     # bad
     if x == nil
@@ -11,14 +8,4 @@ Supported styles are: predicate, comparison.
 
     # good
     if x.nil?
-    end
-
-### Example: EnforcedStyle: comparison
-
-    # bad
-    if x.nil?
-    end
-
-    # good
-    if x == nil
     end

--- a/config/contents/style/numeric_literal_prefix.md
+++ b/config/contents/style/numeric_literal_prefix.md
@@ -1,4 +1,4 @@
-This cop checks for octal, hex, binary, and decimal literals using
+This cop checks for octal, hex, binary and decimal literals using
 uppercase prefixes and corrects them to lowercase prefix
 or no prefix (in case of decimals).
 

--- a/config/contents/style/proc.md
+++ b/config/contents/style/proc.md
@@ -1,4 +1,4 @@
-This cop checks for uses of Proc.new where Kernel#proc
+This cops checks for uses of Proc.new where Kernel#proc
 would be more appropriate.
 
 ### Example:

--- a/config/contents/style/redundant_begin.md
+++ b/config/contents/style/redundant_begin.md
@@ -39,13 +39,3 @@ Currently it checks for code like this:
     rescue => ex
       anything
     end
-
-    # good
-    # Stabby lambdas don't support implicit `begin` in `do-end` blocks.
-    -> do
-      begin
-        foo
-      rescue Bar
-        baz
-      end
-    end

--- a/config/contents/style/stderr_puts.md
+++ b/config/contents/style/stderr_puts.md
@@ -1,6 +1,6 @@
 This cop identifies places where `$stderr.puts` can be replaced by
 `warn`. The latter has the advantage of easily being disabled by,
-the `-W0` interpreter flag or setting `$VERBOSE` to `nil`.
+e.g. the -W0 interpreter flag, or setting $VERBOSE to nil.
 
 ### Example:
     # bad

--- a/config/contents/style/struct_inheritance.md
+++ b/config/contents/style/struct_inheritance.md
@@ -3,14 +3,7 @@ This cop checks for inheritance from Struct.new.
 ### Example:
     # bad
     class Person < Struct.new(:first_name, :last_name)
-      def age
-        42
-      end
     end
 
     # good
-    Person = Struct.new(:first_name, :last_name) do
-      def age
-        42
-      end
-    end
+    Person = Struct.new(:first_name, :last_name)

--- a/config/contents/style/trailing_comma_in_arguments.md
+++ b/config/contents/style/trailing_comma_in_arguments.md
@@ -5,9 +5,6 @@ This cop checks for trailing comma in argument lists.
     method(1, 2,)
 
     # good
-    method(1, 2)
-
-    # good
     method(
       1, 2,
       3,
@@ -24,9 +21,6 @@ This cop checks for trailing comma in argument lists.
     method(1, 2,)
 
     # good
-    method(1, 2)
-
-    # good
     method(
       1,
       2,
@@ -35,9 +29,6 @@ This cop checks for trailing comma in argument lists.
 ### Example: EnforcedStyleForMultiline: no_comma (default)
     # bad
     method(1, 2,)
-
-    # good
-    method(1, 2)
 
     # good
     method(

--- a/config/contents/style/yoda_condition.md
+++ b/config/contents/style/yoda_condition.md
@@ -1,8 +1,8 @@
-This cop can either enforce or forbid Yoda conditions,
-i.e. comparison operations where the order of expression is reversed.
-eg. `5 == x`
+This cop checks for Yoda conditions, i.e. comparison operations where
+readability is reduced because the operands are not ordered the same
+way as they would be ordered in spoken English.
 
-### Example: EnforcedStyle: forbid_for_all_comparison_operators (default)
+### Example: EnforcedStyle: all_comparison_operators (default)
     # bad
     99 == foo
     "bar" != foo
@@ -15,7 +15,7 @@ eg. `5 == x`
     foo <= 42
     bar > 10
 
-### Example: EnforcedStyle: forbid_for_equality_operators_only
+### Example: EnforcedStyle: equality_operators_only
     # bad
     99 == foo
     "bar" != foo
@@ -23,25 +23,3 @@ eg. `5 == x`
     # good
     99 >= foo
     3 < a && a < 5
-
-### Example: EnforcedStyle: require_for_all_comparison_operators
-    # bad
-    foo == 99
-    foo == "bar"
-    foo <= 42
-    bar > 10
-
-    # good
-    99 == foo
-    "bar" != foo
-    42 >= foo
-    10 < bar
-
-### Example: EnforcedStyle: require_for_equality_operators_only
-    # bad
-    99 >= foo
-    3 < a && a < 5
-
-    # good
-    99 == foo
-    "bar" != foo

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -18,7 +18,7 @@ namespace :docs do
       content = File.read(file)
       content = content.gsub(/.*\n\s+(?=module RuboCop)/, "")
 
-      class_doc = content.match(/(\s+#.*)+/).to_s
+      class_doc = content.match(/(\s+#.*)+(?=\n\s+class)/).to_s
       doc_lines = class_doc.
                   gsub(/^\n/, "").
                   gsub("@example", "### Example:").

--- a/spec/support/currently_undocumented_cops.txt
+++ b/spec/support/currently_undocumented_cops.txt
@@ -1,8 +1,4 @@
 RuboCop::Cop::Layout::IndentFirstArgument
-RuboCop::Cop::Lint::MissingCopEnableDirective
 RuboCop::Cop::Metrics::LineLength
-RuboCop::Cop::Performance::FixedSize
-RuboCop::Cop::Style::ConditionalAssignment
-RuboCop::Cop::Style::MethodCallWithArgsParentheses
 
 


### PR DESCRIPTION
This is a bug that I originally found in #168 but we decided to pull out into its own PR since it is a separate thing than upgrading rubocop.

This scraper was missing the documentation on files like `lib/rubocop/cop/style/conditional_assignment.rb` and `lib/rubocop/cop/layout/indent_first_argument.rb` Because they had a comment before the main docs comment. This was causing them to be rejected because the docs were not long enough, despite the fact that these files do in fact have docs.

A solution I am proposing for this problem is to use a look ahead to grab the comments that come immediately before the class definition as this is where the docs comments always are.

Please let me know if this should go into a different branch, or if I should make PRs into multiple branches for this.