### PR TITLE
Add RubocopMinitest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,9 @@ gem "pry", require: false
 gem "rubocop", "0.75.1", require: false
 gem "rubocop-performance", require: false
 gem "rubocop-migrations", require: false
-gem "rubocop-rspec", require: false
+gem "rubocop-minitest", require: false
 gem "rubocop-rails", require: false
+gem "rubocop-rspec", require: false
 gem "safe_yaml"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     rubocop-migrations (0.1.2)
       rubocop (~> 0.41)
+    rubocop-minitest (0.4.1)
+      rubocop (>= 0.74)
     rubocop-performance (1.5.1)
       rubocop (>= 0.71.0)
     rubocop-rails (2.3.2)
@@ -76,6 +78,7 @@ DEPENDENCIES
   rspec
   rubocop (= 0.75.1)
   rubocop-migrations
+  rubocop-minitest
   rubocop-performance
   rubocop-rails
   rubocop-rspec


### PR DESCRIPTION
Hey folks 👋

I don't know if this commit is valid. 

We use rubocop-minitest and it would be great if codeclimate could support it.

This commit includes rubocop-minitest gem in the Gemfile to allow
users that uses it to have their code analyzed with CodeClimate.