### PR TITLE
Pin bundler binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN adduser -u 9000 -D app
 COPY Gemfile Gemfile.lock /usr/src/app/
 
 RUN apk add --update build-base git && \
-    gem install bundler && \
+    gem install bundler -v 2.0.2 && \
     bundle install --quiet -j 4 && \
     chown -R app:app /usr/local/bundle && \
     rm -fr ~/.gem ~/.bundle ~/.wh..gem && \


### PR DESCRIPTION
Fix
```
      engine rubocop failed with status 1 and stderr
/usr/local/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- rubocop (LoadError)
	from /usr/local/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /usr/src/app/lib/cc/engine/rubocop.rb:6:in `<top (required)>'
	from /usr/local/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /usr/local/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /usr/src/app/bin/codeclimate-rubocop:8:in `<main>'
```