### PR TITLE
Support rubocop-rake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "parser", "~> 2.4.0"
 gem "pry", require: false
 gem "rubocop", "~> 0.52.1", require: false
 gem "rubocop-migrations", require: false
+gem "rubocop-rake", require: false
 gem "rubocop-rspec", require: false
 gem "safe_yaml"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,8 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     rubocop-migrations (0.1.2)
       rubocop (~> 0.41)
+    rubocop-rake (0.5.1)
+      rubocop
     rubocop-rspec (1.21.0)
       rubocop (>= 0.52.0)
     ruby-progressbar (1.9.0)
@@ -68,8 +70,9 @@ DEPENDENCIES
   rspec
   rubocop (~> 0.52.1)
   rubocop-migrations
+  rubocop-rake
   rubocop-rspec
   safe_yaml
 
 BUNDLED WITH
-   1.16.1
+   1.17.3


### PR DESCRIPTION
Requested in #217
I could use it in our project as well.
When I include `rubocop-rake` in our `.rubocop.yml` `require` section, the rubocop step in codeclimate fails with:
```
/usr/local/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:117:in `require': cannot load such file -- rubocop-rake (LoadError)
...
```
Since this code runs separately from our codebase, I realized it doesn't matter what I include in our `Gemfile`. This gem must be included here.