### PR TITLE
Updated channel and documentation to Rubocop v0.83.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "activesupport", require: false
 gem "mry", require: false
 gem "parser"
 gem "pry", require: false
-gem "rubocop", "0.82.0", require: false
+gem "rubocop", "0.83.0", require: false
 gem "rubocop-i18n", require: false
 gem "rubocop-migrations", require: false
 gem "rubocop-minitest", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,13 +13,12 @@ GEM
     diff-lcs (1.3)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
-    jaro_winkler (1.5.4)
     method_source (0.9.2)
     minitest (5.13.0)
     mry (0.59.0.0)
       rubocop (>= 0.41.0)
     parallel (1.19.1)
-    parser (2.7.1.1)
+    parser (2.7.1.2)
       ast (~> 2.4.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -41,8 +40,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
-    rubocop (0.82.0)
-      jaro_winkler (~> 1.5.1)
+    rubocop (0.83.0)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
@@ -83,7 +81,7 @@ DEPENDENCIES
   pry
   rake
   rspec
-  rubocop (= 0.82.0)
+  rubocop (= 0.83.0)
   rubocop-i18n
   rubocop-migrations
   rubocop-minitest

--- a/config/contents/layout/empty_lines_around_attribute_accessor.md
+++ b/config/contents/layout/empty_lines_around_attribute_accessor.md
@@ -1,0 +1,22 @@
+Checks for a newline after attribute accessor.
+
+### Example:
+    # bad
+    attr_accessor :foo
+    def do_something
+    end
+
+    # good
+    attr_accessor :foo
+
+    def do_something
+    end
+
+    # good
+    attr_accessor :foo
+    attr_reader :bar
+    attr_writer :baz
+    attr :qux
+
+    def do_something
+    end

--- a/config/contents/layout/multiline_operation_indentation.md
+++ b/config/contents/layout/multiline_operation_indentation.md
@@ -1,28 +1,37 @@
 This cop checks the indentation of the right hand side operand in
 binary operations that span more than one line.
 
+The `aligned` style checks that operators are aligned if they are part
+of an `if` or `while` condition, a `return` statement, etc. In other
+contexts, the second operand should be indented regardless of enforced
+style.
+
 ### Example: EnforcedStyle: aligned (default)
     # bad
     if a +
         b
-      something
+      something &&
+      something_else
     end
 
     # good
     if a +
        b
-      something
+      something &&
+        something_else
     end
 
 ### Example: EnforcedStyle: indented
     # bad
     if a +
        b
-      something
+      something &&
+      something_else
     end
 
     # good
     if a +
         b
-      something
+      something &&
+        something_else
     end

--- a/config/contents/layout/trailing_whitespace.md
+++ b/config/contents/layout/trailing_whitespace.md
@@ -9,14 +9,14 @@ This cop looks for trailing whitespace in the source code.
     # good
     x = 0
 
-### Example: AllowInHeredoc: false (default)
+### Example: AllowInHeredoc: false
     # The line in this example contains spaces after the 0.
     # bad
     code = <<~RUBY
       x = 0
     RUBY
 
-### Example: AllowInHeredoc: true
+### Example: AllowInHeredoc: true (default)
     # The line in this example contains spaces after the 0.
     # good
     code = <<~RUBY

--- a/config/contents/lint/empty_when.md
+++ b/config/contents/lint/empty_when.md
@@ -3,17 +3,38 @@ This cop checks for the presence of `when` branches without a body.
 ### Example:
 
     # bad
-
     case foo
-    when bar then 1
-    when baz then # nothing
+    when bar
+      do_something
+    when baz
     end
 
 ### Example:
 
     # good
+    case condition
+    when foo
+      do_something
+    when bar
+      nil
+    end
 
-    case foo
-    when bar then 1
-    when baz then 2
+### Example: AllowComments: true (default)
+
+    # good
+    case condition
+    when foo
+      do_something
+    when bar
+      # noop
+    end
+
+### Example: AllowComments: false
+
+    # bad
+    case condition
+    when foo
+      do_something
+    when bar
+      # do nothing
     end

--- a/config/contents/lint/literal_as_condition.md
+++ b/config/contents/lint/literal_as_condition.md
@@ -5,23 +5,22 @@ if/while/until.
 ### Example:
 
     # bad
-
     if 20
       do_something
     end
 
-### Example:
-
     # bad
-
     if some_var && true
       do_something
     end
 
-### Example:
-
     # good
-
     if some_var && some_condition
       do_something
+    end
+
+    # good
+    # When using a boolean value for an infinite loop.
+    while true
+      break if condition
     end

--- a/config/contents/lint/parentheses_as_grouped_expression.md
+++ b/config/contents/lint/parentheses_as_grouped_expression.md
@@ -4,11 +4,9 @@ parenthesis.
 ### Example:
 
     # bad
-
-    puts (x + y)
-
-### Example:
+    do_something (foo)
 
     # good
-
-    puts(x + y)
+    do_something(foo)
+    do_something (2 + 3) * 4
+    do_something (foo * bar).baz

--- a/config/contents/style/guard_clause.md
+++ b/config/contents/style/guard_clause.md
@@ -30,3 +30,14 @@ expression
     # good
     raise 'exception' if something
     ok
+
+    # bad
+    if something
+      foo || raise('exception')
+    else
+      ok
+    end
+
+    # good
+    foo || raise('exception') if something
+    ok

--- a/config/contents/style/multiline_when_then.md
+++ b/config/contents/style/multiline_when_then.md
@@ -16,3 +16,9 @@ in multi-line when statements.
     case foo
     when bar then do_something
     end
+
+    # good
+    case foo
+    when bar then do_something(arg1,
+                               arg2)
+    end

--- a/config/contents/style/optional_arguments.md
+++ b/config/contents/style/optional_arguments.md
@@ -1,5 +1,5 @@
 This cop checks for optional arguments to methods
-that do not come at the end of the argument list
+that do not come at the end of the argument list.
 
 ### Example:
     # bad

--- a/config/contents/style/slicing_with_range.md
+++ b/config/contents/style/slicing_with_range.md
@@ -1,0 +1,9 @@
+This cop checks that arrays are sliced with endless ranges instead of
+`ary[start..-1]` on Ruby 2.6+.
+
+### Example:
+    # bad
+    items[1..-1]
+
+    # good
+    items[1..]

--- a/spec/cc/engine/config_upgrader_spec.rb
+++ b/spec/cc/engine/config_upgrader_spec.rb
@@ -13,6 +13,8 @@ module CC::Engine
         end
       CODE
       create_source_file(".rubocop.yml", <<~CONFIG)
+        Layout/EmptyLinesAroundAttributeAccessor:
+          Enabled: true
         Layout/SpaceAroundMethodCallOperator:
           Enabled: false
         Lint/RaiseException:
@@ -30,6 +32,8 @@ module CC::Engine
         Style/HashTransformKeys:
           Enabled: true
         Style/HashTransformValues:
+          Enabled: true
+        Style/SlicingWithRange:
           Enabled: true
       CONFIG
 


### PR DESCRIPTION
This PR proposes to update the Rubocop integration to support v0.83.0. It includes commits from #234 as well, but I'm happy to rework the PR to do a straight upgrade from the 0-81 channel if that's preferable.