### PR TITLE
Support rubocop-rake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "rubocop-migrations", require: false
 gem "rubocop-minitest", require: false
 gem "rubocop-performance", require: false
 gem "rubocop-rails", require: false
+gem "rubocop-rake", require: false
 gem "rubocop-rspec", require: false
 gem "rubocop-thread_safety", require: false
 gem "safe_yaml"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,8 @@ GEM
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
+    rubocop-rake (0.5.1)
+      rubocop
     rubocop-rspec (1.38.1)
       rubocop (>= 0.68.1)
     rubocop-thread_safety (0.3.4)
@@ -87,6 +89,7 @@ DEPENDENCIES
   rubocop-minitest
   rubocop-performance
   rubocop-rails
+  rubocop-rake
   rubocop-rspec
   rubocop-thread_safety
   safe_yaml


### PR DESCRIPTION
Requested in #217
I could use it in our project as well.
When I include rubocop-rake in our .rubocop.yml require section, the rubocop step in codeclimate fails with:

>/usr/local/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:117:in `require': cannot load such file -- rubocop-rake (LoadError)

Since this code runs separately from our codebase, I realized it doesn't matter what I include in our Gemfile. This gem must be included here.

@filipesperandio opening against latest channel