### PR TITLE
Updated channel and documentation to Rubocop v0.85.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "activesupport", require: false
 gem "mry", require: false
 gem "parser"
 gem "pry", require: false
-gem "rubocop", "0.84.0", require: false
+gem "rubocop", "0.85.1", require: false
 gem "rubocop-i18n", require: false
 gem "rubocop-migrations", require: false
 gem "rubocop-minitest", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,7 @@ GEM
     rack (2.0.7)
     rainbow (3.0.0)
     rake (13.0.1)
+    regexp_parser (1.7.1)
     rexml (3.2.4)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -40,10 +41,11 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
-    rubocop (0.84.0)
+    rubocop (0.85.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.7)
       rexml
       rubocop-ast (>= 0.0.3)
       ruby-progressbar (~> 1.7)
@@ -86,7 +88,7 @@ DEPENDENCIES
   pry
   rake
   rspec
-  rubocop (= 0.84.0)
+  rubocop (= 0.85.1)
   rubocop-i18n
   rubocop-migrations
   rubocop-minitest

--- a/config/contents/bundler/gem_comment.md
+++ b/config/contents/bundler/gem_comment.md
@@ -1,6 +1,24 @@
 Add a comment describing each gem in your Gemfile.
 
-### Example:
+Optionally, the "OnlyFor" configuration
+can be used to only register offenses when the gems
+use certain options or have version specifiers.
+Add "version_specifiers" and/or the gem option names
+you want to check.
+
+A useful use-case is to enforce a comment when using
+options that change the source of a gem:
+
+- `bitbucket`
+- `gist`
+- `git`
+- `github`
+- `source`
+
+For a full list of options supported by bundler,
+you can check the https://bundler.io/man/gemfile.5.html[official documentation].
+
+### Example: OnlyFor: [] (default)
     # bad
 
     gem 'foo'
@@ -9,3 +27,28 @@ Add a comment describing each gem in your Gemfile.
 
     # Helpers for the foo things.
     gem 'foo'
+
+### Example: OnlyFor: ['version_specifiers']
+    # bad
+
+    gem 'foo', '< 2.1'
+
+    # good
+
+    # Version 2.1 introduces breaking change baz
+    gem 'foo', '< 2.1'
+
+### Example: OnlyFor: ['version_specifiers', 'github']
+    # bad
+
+    gem 'foo', github: 'some_account/some_fork_of_foo'
+
+    gem 'bar', '< 2.1'
+
+    # good
+
+    # Using this fork because baz
+    gem 'foo', github: 'some_account/some_fork_of_foo'
+
+    # Version 2.1 introduces breaking change baz
+    gem 'bar', '< 2.1'

--- a/config/contents/layout/empty_lines_around_attribute_accessor.md
+++ b/config/contents/layout/empty_lines_around_attribute_accessor.md
@@ -1,6 +1,6 @@
 Checks for a newline after an attribute accessor or a group of them.
-`alias` syntax and `alias_method`, `public`, `protected`, and `private` methods are allowed by default.
-These are customizable with `AllowAliasSyntax` and `AllowedMethods` options.
+`alias` syntax and `alias_method`, `public`, `protected`, and `private` methods are allowed
+by default. These are customizable with `AllowAliasSyntax` and `AllowedMethods` options.
 
 ### Example:
     # bad

--- a/config/contents/layout/first_argument_indentation.md
+++ b/config/contents/layout/first_argument_indentation.md
@@ -2,7 +2,7 @@ This cop checks the indentation of the first argument in a method call.
 Arguments after the first one are checked by Layout/ArgumentAlignment,
 not by this cop.
 
-For indenting the first parameter of method *definitions*, check out
+For indenting the first parameter of method _definitions_, check out
 Layout/FirstParameterIndentation.
 
 ### Example:

--- a/config/contents/layout/first_parameter_indentation.md
+++ b/config/contents/layout/first_parameter_indentation.md
@@ -2,9 +2,9 @@ This cop checks the indentation of the first parameter in a method
 definition. Parameters after the first one are checked by
 Layout/ParameterAlignment, not by this cop.
 
-For indenting the first argument of method *calls*, check out
+For indenting the first argument of method _calls_, check out
 Layout/FirstArgumentIndentation, which supports options related to
-nesting that are irrelevant for method *definitions*.
+nesting that are irrelevant for method _definitions_.
 
 ### Example:
 

--- a/config/contents/layout/hash_alignment.md
+++ b/config/contents/layout/hash_alignment.md
@@ -2,16 +2,16 @@ Check that the keys, separators, and values of a multi-line hash
 literal are aligned according to configuration. The configuration
 options are:
 
-    - key (left align keys, one space before hash rockets and values)
-    - separator (align hash rockets and colons, right align keys)
-    - table (left align keys, hash rockets, and values)
+* key (left align keys, one space before hash rockets and values)
+* separator (align hash rockets and colons, right align keys)
+* table (left align keys, hash rockets, and values)
 
 The treatment of hashes passed as the last argument to a method call
 can also be configured. The options are:
 
-    - always_inspect
-    - always_ignore
-    - ignore_implicit (without curly braces)
+* always_inspect
+* always_ignore
+* ignore_implicit (without curly braces)
 
 Alternatively you can specify multiple allowed styles. That's done by
 passing a list of styles to EnforcedStyles.

--- a/config/contents/layout/heredoc_indentation.md
+++ b/config/contents/layout/heredoc_indentation.md
@@ -1,45 +1,18 @@
 This cop checks the indentation of the here document bodies. The bodies
 are indented one step.
-In Ruby 2.3 or newer, squiggly heredocs (`<<~`) should be used. If you
-use the older rubies, you should introduce some library to your project
-(e.g. ActiveSupport, Powerpack or Unindent).
-Note: When `Layout/LineLength`'s `AllowHeredoc` is false (not default),
+
+Note: When ``Layout/LineLength``'s `AllowHeredoc` is false (not default),
         this cop does not add any offenses for long here documents to
         avoid `Layout/LineLength`'s offenses.
 
-### Example: EnforcedStyle: squiggly (default)
+### Example:
     # bad
     <<-RUBY
     something
     RUBY
 
     # good
-    # When EnforcedStyle is squiggly, bad code is auto-corrected to the
-    # following code.
     <<~RUBY
       something
     RUBY
 
-### Example: EnforcedStyle: active_support
-    # good
-    # When EnforcedStyle is active_support, bad code is auto-corrected to
-    # the following code.
-    <<-RUBY.strip_heredoc
-      something
-    RUBY
-
-### Example: EnforcedStyle: powerpack
-    # good
-    # When EnforcedStyle is powerpack, bad code is auto-corrected to
-    # the following code.
-    <<-RUBY.strip_indent
-      something
-    RUBY
-
-### Example: EnforcedStyle: unindent
-    # good
-    # When EnforcedStyle is unindent, bad code is auto-corrected to
-    # the following code.
-    <<-RUBY.unindent
-      something
-    RUBY

--- a/config/contents/layout/line_length.md
+++ b/config/contents/layout/line_length.md
@@ -14,23 +14,23 @@ If autocorrection is enabled, the following Layout cops
 are recommended to further format the broken lines.
 (Many of these are enabled by default.)
 
-    - ArgumentAlignment
-    - BlockAlignment
-    - BlockDelimiters
-    - BlockEndNewline
-    - ClosingParenthesisIndentation
-    - FirstArgumentIndentation
-    - FirstArrayElementIndentation
-    - FirstHashElementIndentation
-    - FirstParameterIndentation
-    - HashAlignment
-    - IndentationWidth
-    - MultilineArrayLineBreaks
-    - MultilineBlockLayout
-    - MultilineHashBraceLayout
-    - MultilineHashKeyLineBreaks
-    - MultilineMethodArgumentLineBreaks
-    - ParameterAlignment
+* ArgumentAlignment
+* BlockAlignment
+* BlockDelimiters
+* BlockEndNewline
+* ClosingParenthesisIndentation
+* FirstArgumentIndentation
+* FirstArrayElementIndentation
+* FirstHashElementIndentation
+* FirstParameterIndentation
+* HashAlignment
+* IndentationWidth
+* MultilineArrayLineBreaks
+* MultilineBlockLayout
+* MultilineHashBraceLayout
+* MultilineHashKeyLineBreaks
+* MultilineMethodArgumentLineBreaks
+* ParameterAlignment
 
 Together, these cops will pretty print hashes, arrays,
 method calls, etc. For example, let's say the max columns

--- a/config/contents/lint/ensure_return.md
+++ b/config/contents/lint/ensure_return.md
@@ -1,4 +1,4 @@
-This cop checks for *return* from an *ensure* block.
+This cop checks for `return` from an `ensure` block.
 Explicit return from an ensure block alters the control flow
 as the return will take precedence over any exception being raised,
 and the exception will be silently thrown away as if it were rescued.

--- a/config/contents/lint/format_parameter_mismatch.md
+++ b/config/contents/lint/format_parameter_mismatch.md
@@ -2,6 +2,10 @@ This lint sees if there is a mismatch between the number of
 expected fields for format/sprintf/#% and what is actually
 passed as arguments.
 
+In addition it checks whether different formats are used in the same
+format string. Do not mix numbered, unnumbered, and named formats in
+the same format string.
+
 ### Example:
 
     # bad
@@ -13,3 +17,15 @@ passed as arguments.
     # good
 
     format('A value: %s and another: %i', a_value, another)
+
+### Example:
+
+    # bad
+
+    format('Unnumbered format: %s and numbered: %2$s', a_value, another)
+
+### Example:
+
+    # good
+
+    format('Numbered format: %1$s and numbered %2$s', a_value, another)

--- a/config/contents/lint/mixed_regexp_capture_types.md
+++ b/config/contents/lint/mixed_regexp_capture_types.md
@@ -1,0 +1,16 @@
+Do not mix named captures and numbered captures in a Regexp literal
+because numbered capture is ignored if they're mixed.
+Replace numbered captures with non-capturing groupings or
+named captures.
+
+    # bad
+    /(?<foo>FOO)(BAR)/
+
+    # good
+    /(?<foo>FOO)(?<bar>BAR)/
+
+    # good
+    /(?<foo>FOO)(?:BAR)/
+
+    # good
+    /(FOO)(BAR)/

--- a/config/contents/naming/class_and_module_camel_case.md
+++ b/config/contents/naming/class_and_module_camel_case.md
@@ -1,6 +1,12 @@
 This cop checks for class and module names with
 an underscore in them.
 
+`AllowedNames` config takes an array of permitted names.
+Its default value is `['module_parent']`.
+These names can be full class/module names or part of the name.
+eg. Adding `my_class` to the `AllowedNames` config will allow names like
+`my_class`, `my_class::User`, `App::my_class`, `App::my_class::User`, etc.
+
 ### Example:
     # bad
     class My_Class
@@ -12,4 +18,6 @@ an underscore in them.
     class MyClass
     end
     module MyModule
+    end
+    class module_parent::MyModule
     end

--- a/config/contents/style/copyright.md
+++ b/config/contents/style/copyright.md
@@ -3,8 +3,8 @@ Check that a copyright notice was given in each source file.
 The default regexp for an acceptable copyright notice can be found in
 config/default.yml. The default can be changed as follows:
 
-      Style/Copyright:
-        Notice: '^Copyright (\(c\) )?2\d{3} Acme Inc'
+ Style/Copyright:
+     Notice: '^Copyright (\(c\) )?2\d{3} Acme Inc'
 
 This regex string is treated as an unanchored regex. For each file
 that RuboCop scans, a comment that matches this regex must be found or

--- a/config/contents/style/double_negation.md
+++ b/config/contents/style/double_negation.md
@@ -5,12 +5,17 @@ that use boolean as a return value. When using `EnforcedStyle: forbidden`, doubl
 should be forbidden always.
 
 ### Example:
-
     # bad
     !!something
 
     # good
     !something.nil?
+
+### Example: EnforcedStyle: allowed_in_returns (default)
+    # good
+    def foo?
+      !!return_value
+    end
 
 ### Example: EnforcedStyle: forbidden
     # bad

--- a/config/contents/style/frozen_string_literal_comment.md
+++ b/config/contents/style/frozen_string_literal_comment.md
@@ -3,8 +3,7 @@ to frozen string literals.
 It will add the comment `# frozen_string_literal: true` to the top of
 files to enable frozen string literals. Frozen string literals may be
 default in future Ruby. The comment will be added below a shebang and
-encoding comment. The frozen string literal comment is only valid in
-Ruby 2.3+.
+encoding comment.
 
 Note that the cop will ignore files where the comment exists but is set
 to `false` instead of `true`.

--- a/config/contents/style/redundant_regexp_character_class.md
+++ b/config/contents/style/redundant_regexp_character_class.md
@@ -1,0 +1,18 @@
+This cop checks for unnecessary single-element Regexp character classes.
+
+### Example:
+
+    # bad
+    r = /[x]/
+
+    # good
+    r = /x/
+
+    # bad
+    r = /[\s]/
+
+    # good
+    r = /\s/
+
+    # good
+    r = /[ab]/

--- a/config/contents/style/redundant_regexp_escape.md
+++ b/config/contents/style/redundant_regexp_escape.md
@@ -1,0 +1,26 @@
+This cop checks for redundant escapes inside Regexp literals.
+
+### Example:
+    # bad
+    %r{foo\/bar}
+
+    # good
+    %r{foo/bar}
+
+    # good
+    /foo\/bar/
+
+    # good
+    %r/foo\/bar/
+
+    # bad
+    /a\-b/
+
+    # good
+    /a-b/
+
+    # bad
+    /[\+\-]\d/
+
+    # good
+    /[+\-]\d/

--- a/spec/cc/engine/config_upgrader_spec.rb
+++ b/spec/cc/engine/config_upgrader_spec.rb
@@ -19,6 +19,8 @@ module CC::Engine
           Enabled: false
         Lint/DeprecatedOpenSSLConstant:
           Enabled: false
+        Lint/MixedRegexpCaptureTypes:
+          Enabled: true
         Lint/RaiseException:
           Enabled: false
         Lint/StructNewOverride:
@@ -36,6 +38,10 @@ module CC::Engine
         Style/HashTransformValues:
           Enabled: true
         Style/SlicingWithRange:
+          Enabled: true
+        Style/RedundantRegexpCharacterClass:
+          Enabled: true
+        Style/RedundantRegexpEscape:
           Enabled: true
       CONFIG
 


### PR DESCRIPTION
Based on https://github.com/codeclimate/codeclimate-rubocop/pull/238 which is actually pointing to rubocop `0.86`

[Official Rubocop release](https://github.com/rubocop-hq/rubocop/releases/tag/v0.85.0) 