### PR TITLE
Add rubocop-sequel support for rubocop's 0.86

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "rubocop-performance", require: false
 gem "rubocop-rails", require: false
 gem "rubocop-rake", require: false
 gem "rubocop-rspec", require: false
+gem "rubocop-sequel", require: false
 gem "rubocop-thread_safety", require: false
 gem "safe_yaml"
 gem "test-prof", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,8 @@ GEM
       rubocop
     rubocop-rspec (1.41.0)
       rubocop (>= 0.68.1)
+    rubocop-sequel (0.0.6)
+      rubocop (~> 0.55, >= 0.55)
     rubocop-thread_safety (0.4.1)
       rubocop (>= 0.51.0)
     ruby-progressbar (1.10.1)
@@ -97,6 +99,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rake
   rubocop-rspec
+  rubocop-sequel
   rubocop-thread_safety
   safe_yaml
   test-prof


### PR DESCRIPTION
Requested at https://github.com/codeclimate/codeclimate-rubocop/issues/231