### PR TITLE
Updated channel and documentation to Rubocop v0.88

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "activesupport", require: false
 gem "mry", require: false
 gem "parser"
 gem "pry", require: false
-gem "rubocop", "0.87.1", require: false
+gem "rubocop", "0.88", require: false
 gem "rubocop-i18n", require: false
 gem "rubocop-migrations", require: false
 gem "rubocop-minitest", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
-    rubocop (0.87.1)
+    rubocop (0.88.0)
       parallel (~> 1.10)
       parser (>= 2.7.1.1)
       rainbow (>= 2.2.2, < 4.0)
@@ -50,7 +50,7 @@ GEM
       rubocop-ast (>= 0.1.0, < 1.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.1.0)
+    rubocop-ast (0.2.0)
       parser (>= 2.7.0.1)
     rubocop-i18n (2.0.2)
       rubocop (~> 0.51)
@@ -91,7 +91,7 @@ DEPENDENCIES
   pry
   rake
   rspec
-  rubocop (= 0.87.1)
+  rubocop (= 0.88)
   rubocop-i18n
   rubocop-migrations
   rubocop-minitest

--- a/config/contents/gemspec/required_ruby_version.md
+++ b/config/contents/gemspec/required_ruby_version.md
@@ -30,3 +30,8 @@ required by gemspec.
     Gem::Specification.new do |spec|
       spec.required_ruby_version = ['>= 2.5.0', '< 2.7.0']
     end
+
+    # good
+    Gem::Specification.new do |spec|
+      spec.required_ruby_version = '~> 2.5'
+    end

--- a/config/contents/lint/duplicate_elsif_condition.md
+++ b/config/contents/lint/duplicate_elsif_condition.md
@@ -1,0 +1,16 @@
+This cop checks that there are no repeated conditions used in if 'elsif'.
+
+### Example:
+    # bad
+    if x == 1
+      do_something
+    elsif x == 1
+      do_something_else
+    end
+
+    # good
+    if x == 1
+      do_something
+    elsif x == 2
+      do_something_else
+    end

--- a/config/contents/lint/non_deterministic_require_order.md
+++ b/config/contents/lint/non_deterministic_require_order.md
@@ -29,3 +29,19 @@ always sort the list.
     Dir.glob(Rails.root.join(__dir__, 'test', '*.rb')).sort.each do |file|
       require file
     end
+
+### Example:
+
+    # bad
+    Dir['./lib/**/*.rb'].each(&method(:require))
+
+    # good
+    Dir['./lib/**/*.rb'].sort.each(&method(:require))
+
+### Example:
+
+    # bad
+    Dir.glob(Rails.root.join('test', '*.rb'), &method(:require))
+
+    # good
+    Dir.glob(Rails.root.join('test', '*.rb')).sort.each(&method(:require))

--- a/config/contents/style/array_coercion.md
+++ b/config/contents/style/array_coercion.md
@@ -1,0 +1,12 @@
+This cop enforces the use of `Array()` instead of explicit `Array` check or `[*var]`.
+
+### Example:
+    # bad
+    paths = [paths] unless paths.is_a?(Array)
+    paths.each { |path| do_something(path) }
+
+    # bad (always creates a new Array instance)
+    [*paths].each { |path| do_something(path) }
+
+    # good (and a bit more readable)
+    Array(paths).each { |path| do_something(path) }

--- a/config/contents/style/case_like_if.md
+++ b/config/contents/style/case_like_if.md
@@ -1,0 +1,22 @@
+This cop identifies places where `if-elsif` constructions
+can be replaced with `case-when`.
+
+### Example:
+    # bad
+    if status == :active
+      perform_action
+    elsif status == :inactive || status == :hibernating
+      check_timeout
+    else
+      final_action
+    end
+
+    # good
+    case status
+    when :active
+      perform_action
+    when :inactive, :hibernating
+      check_timeout
+    else
+      final_action
+    end

--- a/config/contents/style/hash_as_last_array_item.md
+++ b/config/contents/style/hash_as_last_array_item.md
@@ -1,0 +1,16 @@
+Checks for presence or absence of braces around hash literal as a last
+array item depending on configuration.
+
+### Example: EnforcedStyle: braces (default)
+    # bad
+    [1, 2, one: 1, two: 2]
+
+    # good
+    [1, 2, { one: 1, two: 2 }]
+
+### Example: EnforcedStyle: no_braces
+    # bad
+    [1, 2, { one: 1, two: 2 }]
+
+    # good
+    [1, 2, one: 1, two: 2]

--- a/config/contents/style/hash_like_case.md
+++ b/config/contents/style/hash_like_case.md
@@ -1,0 +1,32 @@
+This cop checks for places where `case-when` represents a simple 1:1
+mapping and can be replaced with a hash lookup.
+
+### Example: MinBranchesCount: 3 (default)
+    # bad
+    case country
+    when 'europe'
+      'http://eu.example.com'
+    when 'america'
+      'http://us.example.com'
+    when 'australia'
+      'http://au.example.com'
+    end
+
+    # good
+    SITES = {
+      'europe'    => 'http://eu.example.com',
+      'america'   => 'http://us.example.com',
+      'australia' => 'http://au.example.com'
+    }
+    SITES[country]
+
+### Example: MinBranchesCount: 4
+    # good
+    case country
+    when 'europe'
+      'http://eu.example.com'
+    when 'america'
+      'http://us.example.com'
+    when 'australia'
+      'http://au.example.com'
+    end

--- a/config/contents/style/redundant_file_extension_in_require.md
+++ b/config/contents/style/redundant_file_extension_in_require.md
@@ -1,0 +1,20 @@
+This cop checks for the presence of superfluous `.rb` extension in
+the filename provided to `require` and `require_relative`.
+
+Note: If the extension is omitted, Ruby tries adding '.rb', '.so',
+        and so on to the name until found. If the file named cannot be found,
+        a `LoadError` will be raised.
+        There is an edge case where `foo.so` file is loaded instead of a `LoadError`
+        if `foo.so` file exists when `require 'foo.rb'` will be changed to `require 'foo'`,
+        but that seems harmless.
+
+### Example:
+    # bad
+    require 'foo.rb'
+    require_relative '../foo.rb'
+
+    # good
+    require 'foo'
+    require 'foo.so'
+    require_relative '../foo'
+    require_relative '../foo.so'

--- a/spec/cc/engine/config_upgrader_spec.rb
+++ b/spec/cc/engine/config_upgrader_spec.rb
@@ -19,6 +19,8 @@ module CC::Engine
           Enabled: false
         Lint/DeprecatedOpenSSLConstant:
           Enabled: false
+        Lint/DuplicateElsifCondition:
+          Enabled: false
         Lint/MixedRegexpCaptureTypes:
           Enabled: true
         Lint/RaiseException:
@@ -31,12 +33,20 @@ module CC::Engine
           Enabled: true
         Style/AccessorMethodName:
           Enabled: false
+        Style/ArrayCoercion:
+          Enabled: false
+        Style/CaseLikeIf:
+          Enabled: false
         Style/ExponentialNotation:
           Enabled: false
         Style/FrozenStringLiteralComment:
           Enabled: false
+        Style/HashAsLastArrayItem:
+          Enabled: false
         Style/HashEachMethods:
           Enabled: true
+        Style/HashLikeCase:
+          Enabled: false
         Style/HashTransformKeys:
           Enabled: true
         Style/HashTransformValues:
@@ -47,6 +57,8 @@ module CC::Engine
           Enabled: true
         Style/SlicingWithRange:
           Enabled: true
+        Style/RedundantFileExtensionInRequire:
+          Enabled: false
         Style/RedundantRegexpCharacterClass:
           Enabled: true
         Style/RedundantRegexpEscape:

--- a/spec/support/currently_undocumented_cops.txt
+++ b/spec/support/currently_undocumented_cops.txt
@@ -1,5 +1,3 @@
-RuboCop::Cop::Layout::IndentFirstArgument
 RuboCop::Cop::Lint::Syntax
-RuboCop::Cop::Metrics::LineLength
 RuboCop::Cop::Migration::DepartmentName
 RuboCop::Cop::Style::ConditionalAssignment


### PR DESCRIPTION
I'm a bit late on this one, and I feel like the Rubocop folks will be releasing v0.89 soon, but oh well!

As a side note, I've been patching the config-upgrader spec, in this and previous PRs, by appending any newly added cops to the ad hoc config file, and disabling them. Is this providing the desired "value" to the spec and/or functionality?
