### PR TITLE
Updated channel and documentation to Rubocop v0.89.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "activesupport", require: false
 gem "mry", require: false
 gem "parser"
 gem "pry", require: false
-gem "rubocop", "0.88", require: false
+gem "rubocop", "0.89.1", require: false
 gem "rubocop-i18n", require: false
 gem "rubocop-migrations", require: false
 gem "rubocop-minitest", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,17 +41,17 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
-    rubocop (0.88.0)
+    rubocop (0.89.1)
       parallel (~> 1.10)
       parser (>= 2.7.1.1)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.7)
       rexml
-      rubocop-ast (>= 0.1.0, < 1.0)
+      rubocop-ast (>= 0.3.0, < 1.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.2.0)
-      parser (>= 2.7.0.1)
+    rubocop-ast (0.3.0)
+      parser (>= 2.7.1.4)
     rubocop-i18n (2.0.2)
       rubocop (~> 0.51)
     rubocop-migrations (0.1.2)
@@ -91,7 +91,7 @@ DEPENDENCIES
   pry
   rake
   rspec
-  rubocop (= 0.88)
+  rubocop (= 0.89.1)
   rubocop-i18n
   rubocop-migrations
   rubocop-minitest

--- a/config/contents/gemspec/required_ruby_version.md
+++ b/config/contents/gemspec/required_ruby_version.md
@@ -1,10 +1,15 @@
-Checks that `required_ruby_version` of gemspec and `TargetRubyVersion`
-of .rubocop.yml are equal.
+Checks that `required_ruby_version` of gemspec is specified and
+equal to `TargetRubyVersion` of .rubocop.yml.
 Thereby, RuboCop to perform static analysis working on the version
 required by gemspec.
 
 ### Example:
     # When `TargetRubyVersion` of .rubocop.yml is `2.5`.
+
+    # bad
+    Gem::Specification.new do |spec|
+      # no `required_ruby_version` specified
+    end
 
     # bad
     Gem::Specification.new do |spec|

--- a/config/contents/lint/binary_operator_with_identical_operands.md
+++ b/config/contents/lint/binary_operator_with_identical_operands.md
@@ -1,0 +1,23 @@
+This cop checks for places where binary operator has identical operands.
+
+It covers arithmetic operators: `+`, `-`, `*`, `/`, `%`, `**`;
+comparison operators: `==`, `===`, `=~`, `>`, `>=`, `<`, `<=`;
+bitwise operators: `|`, `^`, `&`, `<<`, `>>`;
+boolean operators: `&&`, `||`
+and "spaceship" operator - `<=>`.
+
+This cop is marked as unsafe as it does not consider side effects when calling methods
+and thus can generate false positives:
+    if wr.take_char == '\0' && wr.take_char == '\0'
+
+### Example:
+    # bad
+    x.top >= x.top
+
+    if a.x != 0 && a.x != 0
+      do_something
+    end
+
+    def childs?
+      left_child || left_child
+    end

--- a/config/contents/lint/duplicate_rescue_exception.md
+++ b/config/contents/lint/duplicate_rescue_exception.md
@@ -1,0 +1,21 @@
+This cop checks that there are no repeated exceptions
+used in 'rescue' expressions.
+
+### Example:
+    # bad
+    begin
+      something
+    rescue FirstException
+      handle_exception
+    rescue FirstException
+      handle_other_exception
+    end
+
+    # good
+    begin
+      something
+    rescue FirstException
+      handle_exception
+    rescue SecondException
+      handle_other_exception
+    end

--- a/config/contents/lint/empty_conditional_body.md
+++ b/config/contents/lint/empty_conditional_body.md
@@ -1,0 +1,48 @@
+This cop checks for the presence of `if`, `elsif` and `unless` branches without a body.
+### Example:
+    # bad
+    if condition
+    end
+
+    # bad
+    unless condition
+    end
+
+    # bad
+    if condition
+      do_something
+    elsif other_condition
+    end
+
+    # good
+    if condition
+      do_something
+    end
+
+    # good
+    unless condition
+      do_something
+    end
+
+    # good
+    if condition
+      do_something
+    elsif other_condition
+      do_something_else
+    end
+
+### Example: AllowComments: true (default)
+    # good
+    if condition
+      do_something
+    elsif other_condition
+      # noop
+    end
+
+### Example: AllowComments: false
+    # bad
+    if condition
+      do_something
+    elsif other_condition
+      # noop
+    end

--- a/config/contents/lint/ensure_return.md
+++ b/config/contents/lint/ensure_return.md
@@ -1,25 +1,41 @@
 This cop checks for `return` from an `ensure` block.
-Explicit return from an ensure block alters the control flow
-as the return will take precedence over any exception being raised,
+`return` from an ensure block is a dangerous code smell as it
+will take precedence over any exception being raised,
 and the exception will be silently thrown away as if it were rescued.
+
+If you want to rescue some (or all) exceptions, best to do it explicitly
 
 ### Example:
 
     # bad
 
-    begin
+    def foo
       do_something
     ensure
-      do_something_else
-      return
+      cleanup
+      return self
     end
 
 ### Example:
 
     # good
 
-    begin
+    def foo
       do_something
+      self
     ensure
-      do_something_else
+      cleanup
+    end
+
+    # also good
+
+    def foo
+      begin
+        do_something
+      rescue SomeException
+        # Let's ignore this exception
+      end
+      self
+    ensure
+      cleanup
     end

--- a/config/contents/lint/float_comparison.md
+++ b/config/contents/lint/float_comparison.md
@@ -1,0 +1,24 @@
+This cop checks for the presence of precise comparison of floating point numbers.
+
+Floating point values are inherently inaccurate, and comparing them for exact equality
+is almost never the desired semantics. Comparison via the `==/!=` operators checks
+floating-point value representation to be exactly the same, which is very unlikely
+if you perform any arithmetic operations involving precision loss.
+
+### Example:
+    # bad
+    x == 0.1
+    x != 0.1
+
+    # good - using BigDecimal
+    x.to_d == 0.1.to_d
+
+    # good
+    (x - 0.1).abs < Float::EPSILON
+
+    # good
+    tolerance = 0.0001
+    (x - 0.1).abs < tolerance
+
+    # Or some other epsilon based type of comparison:
+    # https://www.embeddeduse.com/2019/08/26/qt-compare-two-floats/

--- a/config/contents/lint/missing_super.md
+++ b/config/contents/lint/missing_super.md
@@ -1,0 +1,33 @@
+This cop checks for the presence of constructors and lifecycle callbacks
+without calls to `super`.
+
+### Example:
+    # bad
+    class Employee < Person
+      def initialize(name, salary)
+        @salary = salary
+      end
+    end
+
+    # good
+    class Employee < Person
+      def initialize(name, salary)
+        super(name)
+        @salary = salary
+      end
+    end
+
+    # bad
+    class Parent
+      def self.inherited(base)
+        do_something
+      end
+    end
+
+    # good
+    class Parent
+      def self.inherited(base)
+        super
+        do_something
+      end
+    end

--- a/config/contents/lint/out_of_range_regexp_ref.md
+++ b/config/contents/lint/out_of_range_regexp_ref.md
@@ -1,0 +1,14 @@
+This cops looks for references of Regexp captures that are out of range
+and thus always returns nil.
+
+### Example:
+
+    /(foo)bar/ =~ 'foobar'
+
+    # bad - always returns nil
+
+    puts $2 # => nil
+
+    # good
+
+    puts $1 # => foo

--- a/config/contents/lint/self_assignment.md
+++ b/config/contents/lint/self_assignment.md
@@ -1,0 +1,12 @@
+This cop checks for self-assignments.
+
+### Example:
+    # bad
+    foo = foo
+    foo, bar = foo, bar
+    Foo = Foo
+
+    # good
+    foo = bar
+    foo, bar = bar, foo
+    Foo = Bar

--- a/config/contents/lint/top_level_return_with_argument.md
+++ b/config/contents/lint/top_level_return_with_argument.md
@@ -1,0 +1,8 @@
+This cop checks for top level return with arguments. If there is a
+top-level return statement with an argument, then the argument is
+always ignored. This is detected automatically since Ruby 2.7.
+
+### Example:
+
+    # Detected since Ruby 2.7
+    return 1 # 1 is always ignored.

--- a/config/contents/lint/unreachable_loop.md
+++ b/config/contents/lint/unreachable_loop.md
@@ -1,0 +1,66 @@
+This cop checks for loops that will have at most one iteration.
+
+A loop that can never reach the second iteration is a possible error in the code.
+In rare cases where only one iteration (or at most one iteration) is intended behavior,
+the code should be refactored to use `if` conditionals.
+
+### Example:
+    # bad
+    while node
+      do_something(node)
+      node = node.parent
+      break
+    end
+
+    # good
+    while node
+      do_something(node)
+      node = node.parent
+    end
+
+    # bad
+    def verify_list(head)
+      item = head
+      begin
+        if verify(item)
+          return true
+        else
+          return false
+        end
+      end while(item)
+    end
+
+    # good
+    def verify_list(head)
+      item = head
+      begin
+        if verify(item)
+          item = item.next
+        else
+          return false
+        end
+      end while(item)
+
+      true
+    end
+
+    # bad
+    def find_something(items)
+      items.each do |item|
+        if something?(item)
+          return item
+        else
+          raise NotFoundError
+        end
+      end
+    end
+
+    # good
+    def find_something(items)
+      items.each do |item|
+        if something?(item)
+          return item
+        end
+      end
+      raise NotFoundError
+    end

--- a/config/contents/style/explicit_block_argument.md
+++ b/config/contents/style/explicit_block_argument.md
@@ -1,0 +1,31 @@
+This cop enforces the use of explicit block argument to avoid writing
+block literal that just passes its arguments to another block.
+
+### Example:
+    # bad
+    def with_tmp_dir
+      Dir.mktmpdir do |tmp_dir|
+        Dir.chdir(tmp_dir) { |dir| yield dir } # block just passes arguments
+      end
+    end
+
+    # bad
+    def nine_times
+      9.times { yield }
+    end
+
+    # good
+    def with_tmp_dir(&block)
+      Dir.mktmpdir do |tmp_dir|
+        Dir.chdir(tmp_dir, &block)
+      end
+    end
+
+    with_tmp_dir do |dir|
+      puts "dir is accessible as a parameter and pwd is set: #{dir}"
+    end
+
+    # good
+    def nine_times(&block)
+      9.times(&block)
+    end

--- a/config/contents/style/global_std_stream.md
+++ b/config/contents/style/global_std_stream.md
@@ -1,0 +1,23 @@
+This cop enforces the use of `$stdout/$stderr/$stdin` instead of `STDOUT/STDERR/STDIN`.
+`STDOUT/STDERR/STDIN` are constants, and while you can actually
+reassign (possibly to redirect some stream) constants in Ruby, you'll get
+an interpreter warning if you do so.
+
+### Example:
+    # bad
+    STDOUT.puts('hello')
+
+    hash = { out: STDOUT, key: value }
+
+    def m(out = STDOUT)
+      out.puts('hello')
+    end
+
+    # good
+    $stdout.puts('hello')
+
+    hash = { out: $stdout, key: value }
+
+    def m(out = $stdout)
+      out.puts('hello')
+    end

--- a/config/contents/style/optional_boolean_parameter.md
+++ b/config/contents/style/optional_boolean_parameter.md
@@ -1,0 +1,19 @@
+This cop checks for places where keyword arguments can be used instead of
+boolean arguments when defining methods.
+
+### Example:
+    # bad
+    def some_method(bar = false)
+      puts bar
+    end
+
+    # bad - common hack before keyword args were introduced
+    def some_method(options = {})
+      bar = options.fetch(:bar, false)
+      puts bar
+    end
+
+    # good
+    def some_method(bar: false)
+      puts bar
+    end

--- a/config/contents/style/single_argument_dig.md
+++ b/config/contents/style/single_argument_dig.md
@@ -1,0 +1,19 @@
+Sometimes using dig method ends up with just a single
+argument. In such cases, dig should be replaced with [].
+
+### Example:
+    # bad
+    { key: 'value' }.dig(:key)
+    [1, 2, 3].dig(0)
+
+    # good
+    { key: 'value' }[:key]
+    [1, 2, 3][0]
+
+    # good
+    { key1: { key2: 'value' } }.dig(:key1, :key2)
+    [1, [2, [3]]].dig(1, 1)
+
+    # good
+    keys = %i[key1 key2]
+    { key1: { key2: 'value' } }.dig(*keys)

--- a/config/contents/style/string_concatenation.md
+++ b/config/contents/style/string_concatenation.md
@@ -1,0 +1,10 @@
+This cop checks for places where string concatenation
+can be replaced with string interpolation.
+
+### Example:
+    # bad
+    email_with_name = user.name + ' <' + user.email + '>'
+
+    # good
+    email_with_name = "#{user.name} <#{user.email}>"
+    email_with_name = format('%s <%s>', user.name, user.email)

--- a/spec/cc/engine/config_upgrader_spec.rb
+++ b/spec/cc/engine/config_upgrader_spec.rb
@@ -17,16 +17,34 @@ module CC::Engine
           Enabled: true
         Layout/SpaceAroundMethodCallOperator:
           Enabled: false
+        Lint/BinaryOperatorWithIdenticalOperands:
+          Enabled: false
         Lint/DeprecatedOpenSSLConstant:
           Enabled: false
         Lint/DuplicateElsifCondition:
           Enabled: false
+        Lint/DuplicateRescueException:
+          Enabled: false
+        Lint/EmptyConditionalBody:
+          Enabled: false
+        Lint/FloatComparison:
+          Enabled: false
+        Lint/MissingSuper:
+          Enabled: false
         Lint/MixedRegexpCaptureTypes:
           Enabled: true
+        Lint/OutOfRangeRegexpRef:
+          Enabled: false
         Lint/RaiseException:
+          Enabled: false
+        Lint/SelfAssignment:
           Enabled: false
         Lint/StructNewOverride:
           Enabled: false
+        Lint/TopLevelReturnWithArgument:
+          Enabled: false
+        Lint/UnreachableLoop:
+            Enabled: false
         Style/AccessorGrouping:
           Enabled: true
         Style/BisectedAttrAccessor:
@@ -37,9 +55,13 @@ module CC::Engine
           Enabled: false
         Style/CaseLikeIf:
           Enabled: false
+        Style/ExplicitBlockArgument:
+          Enabled: false
         Style/ExponentialNotation:
           Enabled: false
         Style/FrozenStringLiteralComment:
+          Enabled: false
+        Style/GlobalStdStream:
           Enabled: false
         Style/HashAsLastArrayItem:
           Enabled: false
@@ -51,12 +73,18 @@ module CC::Engine
           Enabled: true
         Style/HashTransformValues:
           Enabled: true
+        Style/OptionalBooleanParameter:
+          Enabled: false
         Style/RedundantAssignment:
           Enabled: true
         Style/RedundantFetchBlock:
           Enabled: true
+        Style/SingleArgumentDig:
+          Enabled: false
         Style/SlicingWithRange:
           Enabled: true
+        Style/StringConcatenation:
+          Enabled: false
         Style/RedundantFileExtensionInRequire:
           Enabled: false
         Style/RedundantRegexpCharacterClass:

--- a/spec/cc/engine/config_upgrader_spec.rb
+++ b/spec/cc/engine/config_upgrader_spec.rb
@@ -12,86 +12,9 @@ module CC::Engine
           true
         end
       CODE
-      create_source_file(".rubocop.yml", <<~CONFIG)
-        Layout/EmptyLinesAroundAttributeAccessor:
-          Enabled: true
-        Layout/SpaceAroundMethodCallOperator:
-          Enabled: false
-        Lint/BinaryOperatorWithIdenticalOperands:
-          Enabled: false
-        Lint/DeprecatedOpenSSLConstant:
-          Enabled: false
-        Lint/DuplicateElsifCondition:
-          Enabled: false
-        Lint/DuplicateRescueException:
-          Enabled: false
-        Lint/EmptyConditionalBody:
-          Enabled: false
-        Lint/FloatComparison:
-          Enabled: false
-        Lint/MissingSuper:
-          Enabled: false
-        Lint/MixedRegexpCaptureTypes:
-          Enabled: true
-        Lint/OutOfRangeRegexpRef:
-          Enabled: false
-        Lint/RaiseException:
-          Enabled: false
-        Lint/SelfAssignment:
-          Enabled: false
-        Lint/StructNewOverride:
-          Enabled: false
-        Lint/TopLevelReturnWithArgument:
-          Enabled: false
-        Lint/UnreachableLoop:
-            Enabled: false
-        Style/AccessorGrouping:
-          Enabled: true
-        Style/BisectedAttrAccessor:
-          Enabled: true
-        Style/AccessorMethodName:
-          Enabled: false
-        Style/ArrayCoercion:
-          Enabled: false
-        Style/CaseLikeIf:
-          Enabled: false
-        Style/ExplicitBlockArgument:
-          Enabled: false
-        Style/ExponentialNotation:
-          Enabled: false
-        Style/FrozenStringLiteralComment:
-          Enabled: false
-        Style/GlobalStdStream:
-          Enabled: false
-        Style/HashAsLastArrayItem:
-          Enabled: false
-        Style/HashEachMethods:
-          Enabled: true
-        Style/HashLikeCase:
-          Enabled: false
-        Style/HashTransformKeys:
-          Enabled: true
-        Style/HashTransformValues:
-          Enabled: true
-        Style/OptionalBooleanParameter:
-          Enabled: false
-        Style/RedundantAssignment:
-          Enabled: true
-        Style/RedundantFetchBlock:
-          Enabled: true
-        Style/SingleArgumentDig:
-          Enabled: false
-        Style/SlicingWithRange:
-          Enabled: true
-        Style/StringConcatenation:
-          Enabled: false
-        Style/RedundantFileExtensionInRequire:
-          Enabled: false
-        Style/RedundantRegexpCharacterClass:
-          Enabled: true
-        Style/RedundantRegexpEscape:
-          Enabled: true
-      CONFIG
+
+      create_source_file(".rubocop.yml",
+                         File.read("spec/support/config_upgrader_rubocop.yml"))
 
       # No warnings about obsolete cop name
       expect do

--- a/spec/support/config_upgrader_rubocop.yml
+++ b/spec/support/config_upgrader_rubocop.yml
@@ -1,0 +1,78 @@
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: false
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: false
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: false
+Lint/DuplicateElsifCondition:
+  Enabled: false
+Lint/DuplicateRescueException:
+  Enabled: false
+Lint/EmptyConditionalBody:
+  Enabled: false
+Lint/FloatComparison:
+  Enabled: false
+Lint/MissingSuper:
+  Enabled: false
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+Lint/OutOfRangeRegexpRef:
+  Enabled: false
+Lint/RaiseException:
+  Enabled: false
+Lint/SelfAssignment:
+  Enabled: false
+Lint/StructNewOverride:
+  Enabled: false
+Lint/TopLevelReturnWithArgument:
+  Enabled: false
+Lint/UnreachableLoop:
+    Enabled: false
+Style/AccessorGrouping:
+  Enabled: true
+Style/BisectedAttrAccessor:
+  Enabled: true
+Style/AccessorMethodName:
+  Enabled: false
+Style/ArrayCoercion:
+  Enabled: false
+Style/CaseLikeIf:
+  Enabled: false
+Style/ExplicitBlockArgument:
+  Enabled: false
+Style/ExponentialNotation:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/GlobalStdStream:
+  Enabled: false
+Style/HashAsLastArrayItem:
+  Enabled: false
+Style/HashEachMethods:
+  Enabled: true
+Style/HashLikeCase:
+  Enabled: false
+Style/HashTransformKeys:
+  Enabled: true
+Style/HashTransformValues:
+  Enabled: true
+Style/OptionalBooleanParameter:
+  Enabled: false
+Style/RedundantAssignment:
+  Enabled: true
+Style/RedundantFetchBlock:
+  Enabled: true
+Style/SingleArgumentDig:
+  Enabled: false
+Style/SlicingWithRange:
+  Enabled: true
+Style/StringConcatenation:
+  Enabled: false
+Style/RedundantFileExtensionInRequire:
+  Enabled: false
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+Style/RedundantRegexpEscape:
+  Enabled: true


### PR DESCRIPTION
A whole mess of new cops in this release. The config-upgrader spec is getting kind unwieldy, so I extracted the upgrader's `.rubocop.yml` to a fixture file. Happy to make any requested changes!