### PR TITLE
Updates Readme's installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ You can find some basic setup instructions and links to the RuboCop OSS project 
       rubocop:
         enabled: true
     ```
-2. Run `codeclimate engines:install`. This command installs the engines enabled it in your `.codeclimate.yml` file.
 3. You're ready to analyze! Browse into your project's folder and run `codeclimate analyze`.
 
 ### Need help?

--- a/README.md
+++ b/README.md
@@ -11,7 +11,13 @@ You can find some basic setup instructions and links to the RuboCop OSS project 
 ### Installation
 
 1. If you haven't already, [install the Code Climate CLI](https://github.com/codeclimate/codeclimate).
-2. Run `codeclimate engines:enable rubocop`. This command both installs the engine and enables it in your `.codeclimate.yml` file.
+2. Enable the engine by adding the following under `plugins` in your `.codeclimate.yaml`:
+    ```yaml
+    plugins:
+      rubocop:
+        enabled: true
+    ```
+2. Run `codeclimate engines:install`. This command installs the engines enabled it in your `.codeclimate.yml` file.
 3. You're ready to analyze! Browse into your project's folder and run `codeclimate analyze`.
 
 ### Need help?


### PR DESCRIPTION
The installation steps are outdated: `engines:enable` has been replaced for `engines:install` and it no longer add it to `codeclimate.yml.`

Disclaimer: this is NOT for hacktoberfest!