### PR TITLE
make mry config upgrading optional

### DIFF
--- a/lib/cc/engine/rubocop.rb
+++ b/lib/cc/engine/rubocop.rb
@@ -5,7 +5,6 @@ require "delegate"
 require "pathname"
 require "rubocop"
 require "rubocop/config_patch"
-require "cc/engine/config_upgrader"
 require "cc/engine/source_file"
 require "cc/engine/category_parser"
 require "cc/engine/file_list_resolver"
@@ -24,6 +23,7 @@ module CC
       end
 
       def run
+        check_mry_dependency
         Dir.chdir(root) do
           files_to_inspect.each do |path|
             SourceFile.new(
@@ -54,6 +54,11 @@ module CC
             config_store.options_config = config_file
           end
         end
+      end
+
+      # MRY fell behind, may negatively alter rubocop config
+      def check_mry_dependency
+        require "cc/engine/config_upgrader" unless engine_config.dig("checks", "mry", "disabled")
       end
     end
   end

--- a/spec/cc/engine/config_upgrader_spec.rb
+++ b/spec/cc/engine/config_upgrader_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "cc/engine/config_upgrader"
 
 module CC::Engine
   describe ConfigUpgrader do

--- a/spec/cc/engine/rubocop_spec.rb
+++ b/spec/cc/engine/rubocop_spec.rb
@@ -258,6 +258,22 @@ module CC::Engine
 
         expect(issues).to_not include_check "Lint/UselessAssignment"
       end
+
+      it "does not upgrade the RuboCop config if Mry is disabled" do
+        create_source_file("test.rb", <<~CODE)
+          def get_true
+            true
+          end
+        CODE
+        create_source_file(".rubocop.yml", <<~CONFIG)
+          Layout/EmptyLinesAroundAttributeAccessor:
+            Enabled: true
+        CONFIG
+
+        expect do
+          run_engine("checks" => {"mry" => {"disabled" => false}})
+        end.to output.to_stderr
+      end
     end
   end
 end


### PR DESCRIPTION
In investigating [#251 Layout/FirstArgumentIndentation config options do not match rubocop mainline](#251) I learned we rely on the [Mry](https://github.com/pocke/mry) gem to automagically update RuboCop configs between as RuboCop version change. On one hand this is nice because it brings outdated configs inline with the newer versions of RuboCop without manually checking and updating all the changing configs. Unfortunately Mry hasn't been updated since RuboCop version 0.78 and it's not negatively changing some config values that have been further modified since 0.78. Mry also never supported splitting cops or deleting cops.  

In the case of the open issue here I think there was a combination of problems, one was with handling a split cop and the other is how it handles renamed cops that have been renamed again in more recent Rubocop versions. I added a config check to disable mry.  By default it's enabled so users won't see any new, unexpected errors unless they choose to opt out of the mry config upgrading.

To disable rubocop plugin in `.codeclimate.yml` should look something like:

```
rubocop:
  enabled: true
  channel: rubocop-0-88
  checks:
    mry:
      disabled: true
```


## Test Locally
- Pull down this branch and run 
```
IMAGE_NAME=codeclimate/codeclimate-rubocop-test make image
```
- In the project of your choice replace the current rubocop plugin in `.codeclimate.yml` with:
```
  rubocop-test:
    enabled: true
    checks:
      mry:
        disabled: true
```
- In the terminal of the project run:
```bash
codeclimate engines:install #removes the existing rubocop plugin
codeclimate analyze -e rubocop-test --dev #runs the CLI with the local engine
```



I tested this by adding the Layout/FirstArgumentIndentation cop to my rubocop yaml file with an invalid style.

```
Layout/FirstArgumentIndentation:
  EnforcedStyle: invalid_style
```
When running with Mry enabled I got an invalid EnforcedStyle error with the message:
```
Valid choices are: consistent, align_parentheses
```
This is incorrect, as Mry seems to direct the `FirstArgumentIndentation` to the `FirstParameterIndention`cop. When I disable Mry and run the analyze again I get the expected SupportedStyles for the cop:
```
Valid choices are: consistent, consistent_relative_to_receiver, special_for_inner_method_call, special_for_inner_method_call_in_parentheses
``` 


## Alternatives
I considered making pull requests to the Mry project rather than making this PR, but I think this is the most effective approach given how long it's been since Mry was updated. Also RuboCop just released version 1.0 so I imagine the cops will be more stable going forward and we might consider dropping Mry completely when we release new versions. If users choose to disable Mry they may need to spend some time updating older cops manually, but they'll see error messages related to those so it may end up just being tedious, rather than challenging to migrate off the Mry support.