### PR TITLE
add support for rubocop-sorbet 0.5.1 (channel rubococp-0-92)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "rubocop-rails", require: false
 gem "rubocop-rake", require: false
 gem "rubocop-rspec", require: false
 gem "rubocop-sequel", require: false
+gem 'rubocop-sorbet', require: false
 gem "rubocop-thread_safety", require: false
 gem "safe_yaml"
 gem "test-prof", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,8 @@ GEM
       rubocop (>= 0.68.1)
     rubocop-sequel (0.0.6)
       rubocop (~> 0.55, >= 0.55)
+    rubocop-sorbet (0.5.1)
+      rubocop
     rubocop-thread_safety (0.4.1)
       rubocop (>= 0.51.0)
     ruby-progressbar (1.10.1)
@@ -100,6 +102,7 @@ DEPENDENCIES
   rubocop-rake
   rubocop-rspec
   rubocop-sequel
+  rubocop-sorbet
   rubocop-thread_safety
   safe_yaml
   test-prof


### PR DESCRIPTION
Resolves #232 

Add's support for the [rubocop-sorbet](https://github.com/Shopify/rubocop-sorbet) plugin in channel `rubocop-0-92`.

 I made a test project to run the codeclimate CLI against: https://github.com/britneywright/rubocop-sorbet-test

For local testing:
- Pull down this PR
  - `IMAGE_NAME=codeclimate/codeclimate-rubocop-test make image`
- Pull down the [rubocop-sorbet-test](https://github.com/britneywright/rubocop-sorbet-test) project
  - `bundle install`
  - `codeclimate analyze -e rubocop-test --dev`

Should see an output similar to the following:
```
Starting analysis
Running rubocop-test: Done!

== Gemfile (2 issues) ==
1: No Sorbet sigil found in file. Try a `typed: true` to start (you can also use `rubocop -a` to automatically add this). [rubocop-test]
1: Prefer single-quoted strings when you don't need string interpolation or special symbols. [rubocop-test]

== thing.rb (2 issues) ==
1: No Sorbet sigil found in file. Try a `typed: false` to start (you can also use `rubocop -a` to automatically add this). [rubocop-test]
1: No Sorbet sigil found in file. Try a `typed: true` to start (you can also use `rubocop -a` to automatically add this). [rubocop-test]

Analysis complete! Found 4 issues.
```
