### PR TITLE
Updated channel and documentation to Rubocop v1.7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,8 @@ gem "rubocop-performance", require: false
 gem "rubocop-rails", require: false
 gem "rubocop-rake", require: false
 gem "rubocop-rspec", require: false
-gem "rubocop-sequel", "0.1.0", require: false
-gem 'rubocop-sorbet', require: false
+gem "rubocop-sequel", require: false
+gem "rubocop-sorbet", require: false
 gem "rubocop-thread_safety", require: false
 gem "safe_yaml"
 gem "test-prof", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,15 +6,14 @@ gem "activesupport", require: false
 gem "mry", require: false
 gem "parser"
 gem "pry", require: false
-gem "rubocop", "0.92.0", require: false
+gem "rubocop", "1.7.0", require: false
 gem "rubocop-i18n", require: false
-gem "rubocop-migrations", require: false
 gem "rubocop-minitest", require: false
 gem "rubocop-performance", require: false
 gem "rubocop-rails", require: false
 gem "rubocop-rake", require: false
 gem "rubocop-rspec", require: false
-gem "rubocop-sequel", require: false
+gem "rubocop-sequel", "0.1.0", require: false
 gem 'rubocop-sorbet', require: false
 gem "rubocop-thread_safety", require: false
 gem "safe_yaml"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rake
   rubocop-rspec
-  rubocop-sequel (= 0.1.0)
+  rubocop-sequel
   rubocop-sorbet
   rubocop-thread_safety
   safe_yaml

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,8 +17,8 @@ GEM
     minitest (5.14.1)
     mry (0.78.0.0)
       rubocop (>= 0.41.0)
-    parallel (1.19.2)
-    parser (2.7.1.5)
+    parallel (1.20.1)
+    parser (3.0.0.0)
       ast (~> 2.4.1)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -26,7 +26,7 @@ GEM
     rack (2.2.3)
     rainbow (3.0.0)
     rake (13.0.1)
-    regexp_parser (1.8.1)
+    regexp_parser (2.0.3)
     rexml (3.2.4)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -41,21 +41,19 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
-    rubocop (0.92.0)
+    rubocop (1.7.0)
       parallel (~> 1.10)
       parser (>= 2.7.1.5)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.7)
+      regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 0.5.0)
+      rubocop-ast (>= 1.2.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.7.1)
+    rubocop-ast (1.4.0)
       parser (>= 2.7.1.5)
-    rubocop-i18n (2.0.2)
-      rubocop (~> 0.51)
-    rubocop-migrations (0.1.2)
-      rubocop (~> 0.41)
+    rubocop-i18n (3.0.0)
+      rubocop (~> 1.0)
     rubocop-minitest (0.9.0)
       rubocop (>= 0.74)
     rubocop-performance (1.7.0)
@@ -68,13 +66,13 @@ GEM
       rubocop
     rubocop-rspec (1.41.0)
       rubocop (>= 0.68.1)
-    rubocop-sequel (0.0.6)
-      rubocop (~> 0.55, >= 0.55)
+    rubocop-sequel (0.1.0)
+      rubocop (~> 1.0)
     rubocop-sorbet (0.5.1)
       rubocop
     rubocop-thread_safety (0.4.1)
       rubocop (>= 0.51.0)
-    ruby-progressbar (1.10.1)
+    ruby-progressbar (1.11.0)
     safe_yaml (1.0.5)
     test-prof (0.11.3)
     thread_safe (0.3.6)
@@ -93,15 +91,14 @@ DEPENDENCIES
   pry
   rake
   rspec
-  rubocop (= 0.92.0)
+  rubocop (= 1.7.0)
   rubocop-i18n
-  rubocop-migrations
   rubocop-minitest
   rubocop-performance
   rubocop-rails
   rubocop-rake
   rubocop-rspec
-  rubocop-sequel
+  rubocop-sequel (= 0.1.0)
   rubocop-sorbet
   rubocop-thread_safety
   safe_yaml

--- a/config/contents/bundler/duplicated_gem.md
+++ b/config/contents/bundler/duplicated_gem.md
@@ -20,3 +20,12 @@ A Gem's requirements should be listed only once in a Gemfile.
 
     # good
     gem 'rubocop', groups: [:development, :test]
+
+    # good - conditional declaration
+    if Dir.exist?(local)
+      gem 'rubocop', path: local
+    elsif ENV['RUBOCOP_VERSION'] == 'master'
+      gem 'rubocop', git: 'https://github.com/rubocop-hq/rubocop.git'
+    else
+      gem 'rubocop', '~> 0.90.0'
+    end

--- a/config/contents/gemspec/required_ruby_version.md
+++ b/config/contents/gemspec/required_ruby_version.md
@@ -31,12 +31,13 @@ required by gemspec.
       spec.required_ruby_version = '>= 2.5'
     end
 
-    # good
+    # accepted but not recommended
     Gem::Specification.new do |spec|
       spec.required_ruby_version = ['>= 2.5.0', '< 2.7.0']
     end
 
-    # good
+    # accepted but not recommended, since
+    # Ruby does not really follow semantic versionning
     Gem::Specification.new do |spec|
       spec.required_ruby_version = '~> 2.5'
     end

--- a/config/contents/layout/else_alignment.md
+++ b/config/contents/layout/else_alignment.md
@@ -1,5 +1,5 @@
 This cop checks the alignment of else keywords. Normally they should
-be aligned with an if/unless/while/until/begin/def keyword, but there
+be aligned with an if/unless/while/until/begin/def/rescue keyword, but there
 are special cases when they should follow the same rules as the
 alignment of end.
 

--- a/config/contents/layout/empty_line_between_defs.md
+++ b/config/contents/layout/empty_line_between_defs.md
@@ -1,14 +1,15 @@
-This cop checks whether method definitions are
-separated by one empty line.
+This cop checks whether class/module/method definitions are
+separated by one or more empty lines.
 
 `NumberOfEmptyLines` can be an integer (default is 1) or
 an array (e.g. [1, 2]) to specify a minimum and maximum
 number of empty lines permitted.
 
 `AllowAdjacentOneLineDefs` configures whether adjacent
-one-line method definitions are considered an offense.
+one-line definitions are considered an offense.
 
-### Example:
+### Example: EmptyLineBetweenMethodDefs: true (default)
+    # checks for empty lines between method definitions.
 
     # bad
     def a
@@ -24,3 +25,56 @@ one-line method definitions are considered an offense.
 
     def b
     end
+
+### Example: EmptyLineBetweenClassDefs: true (default)
+    # checks for empty lines between class definitions.
+
+    # bad
+    class A
+    end
+    class B
+    end
+    def b
+    end
+
+### Example:
+
+    # good
+    class A
+    end
+
+    class B
+    end
+
+    def b
+    end
+
+### Example: EmptyLineBetweenModuleDefs: true (default)
+    # checks for empty lines between module definitions.
+
+    # bad
+    module A
+    end
+    module B
+    end
+    def b
+    end
+
+### Example:
+
+    # good
+    module A
+    end
+
+    module B
+    end
+
+    def b
+    end
+
+### Example: AllowAdjacentOneLineDefs: true
+
+    # good
+    class ErrorA < BaseError; end
+    class ErrorB < BaseError; end
+    class ErrorC < BaseError; end

--- a/config/contents/layout/space_around_operators.md
+++ b/config/contents/layout/space_around_operators.md
@@ -1,5 +1,7 @@
 Checks that operators have space around them, except for ** which
 should or shouldn't have surrounding space depending on configuration.
+It allows vertical alignment consisting of one or more whitespace
+around operators.
 
 This cop has `AllowForAlignment` option. When `true`, allows most
 uses of extra spacing if the intent is to align with an operator on

--- a/config/contents/layout/space_before_brackets.md
+++ b/config/contents/layout/space_before_brackets.md
@@ -1,0 +1,14 @@
+Checks for space between the name of a receiver and a left
+brackets.
+
+This cop is marked as unsafe because it can occur false positives
+for `do_something [this_is_an_array_literal_argument]` that take
+an array without parentheses as an argument.
+
+### Example:
+
+    # bad
+    collection [index_or_key]
+
+    # good
+    collection[index_or_key]

--- a/config/contents/layout/space_inside_parens.md
+++ b/config/contents/layout/space_inside_parens.md
@@ -6,10 +6,12 @@ Checks for spaces inside ordinary round parentheses.
     # bad
     f( 3)
     g = (a + 3 )
+    f( )
 
     # good
     f(3)
     g = (a + 3)
+    f()
 
 ### Example: EnforcedStyle: space
     # The `space` style enforces that parentheses have a space at the

--- a/config/contents/layout/trailing_whitespace.md
+++ b/config/contents/layout/trailing_whitespace.md
@@ -9,14 +9,25 @@ This cop looks for trailing whitespace in the source code.
     # good
     x = 0
 
-### Example: AllowInHeredoc: false
+### Example: AllowInHeredoc: false (default)
     # The line in this example contains spaces after the 0.
     # bad
     code = <<~RUBY
       x = 0
     RUBY
 
-### Example: AllowInHeredoc: true (default)
+    # ok
+    code = <<~RUBY
+      x = 0 #{}
+    RUBY
+
+    # good
+    trailing_whitespace = ' '
+    code = <<~RUBY
+      x = 0#{trailing_whitespace}
+    RUBY
+
+### Example: AllowInHeredoc: true
     # The line in this example contains spaces after the 0.
     # good
     code = <<~RUBY

--- a/config/contents/lint/ambiguous_assignment.md
+++ b/config/contents/lint/ambiguous_assignment.md
@@ -1,0 +1,14 @@
+This cop checks for mistyped shorthand assignments.
+
+### Example:
+    # bad
+    x =- y
+    x =+ y
+    x =* y
+    x =! y
+
+    # good
+    x -= y # or x = -y
+    x += y # or x = +y
+    x *= y # or x = *y
+    x != y # or x = !y

--- a/config/contents/lint/ambiguous_block_association.md
+++ b/config/contents/lint/ambiguous_block_association.md
@@ -10,6 +10,8 @@ when param passed without parentheses.
 
     # good
     # With parentheses, there's no ambiguity.
+    some_method(a { |val| puts val })
+    # or (different meaning)
     some_method(a) { |val| puts val }
 
     # good

--- a/config/contents/lint/binary_operator_with_identical_operands.md
+++ b/config/contents/lint/binary_operator_with_identical_operands.md
@@ -12,6 +12,7 @@ and thus can generate false positives:
 
 ### Example:
     # bad
+    x / x
     x.top >= x.top
 
     if a.x != 0 && a.x != 0
@@ -21,3 +22,7 @@ and thus can generate false positives:
     def childs?
       left_child || left_child
     end
+
+    # good
+    x + x
+    1 << 1

--- a/config/contents/lint/constant_definition_in_block.md
+++ b/config/contents/lint/constant_definition_in_block.md
@@ -44,3 +44,14 @@ For meta-programming, use `const_set`.
         const_set(:LIST, [])
       end
     end
+
+### Example: AllowedMethods: ['enums'] (default)
+    # good
+
+    # `enums` for Typed Enums via `T::Enum` in Sorbet.
+    # https://sorbet.org/docs/tenum
+    class TestEnum < T::Enum
+      enums do
+        Foo = new("foo")
+      end
+    end

--- a/config/contents/lint/debugger.md
+++ b/config/contents/lint/debugger.md
@@ -1,4 +1,5 @@
 This cop checks for calls to debugger or pry.
+The cop can be configured to define which methods and receivers must be fixed.
 
 ### Example:
 

--- a/config/contents/lint/duplicate_branch.md
+++ b/config/contents/lint/duplicate_branch.md
@@ -1,0 +1,79 @@
+This cop checks that there are no repeated bodies
+within `if/unless`, `case-when` and `rescue` constructs.
+
+With `IgnoreLiteralBranches: true`, branches are not registered
+as offenses if they return a basic literal value (string, symbol,
+integer, float, rational, complex, `true`, `false`, or `nil`), or
+return an array, hash, regexp or range that only contains one of
+the above basic literal values.
+
+With `IgnoreConstantBranches: true`, branches are not registered
+as offenses if they return a constant value.
+
+### Example:
+    # bad
+    if foo
+      do_foo
+      do_something_else
+    elsif bar
+      do_foo
+      do_something_else
+    end
+
+    # good
+    if foo || bar
+      do_foo
+      do_something_else
+    end
+
+    # bad
+    case x
+    when foo
+      do_foo
+    when bar
+      do_foo
+    else
+      do_something_else
+    end
+
+    # good
+    case x
+    when foo, bar
+      do_foo
+    else
+      do_something_else
+    end
+
+    # bad
+    begin
+      do_something
+    rescue FooError
+      handle_error
+    rescue BarError
+      handle_error
+    end
+
+    # good
+    begin
+      do_something
+    rescue FooError, BarError
+      handle_error
+    end
+
+### Example: IgnoreLiteralBranches: true
+    # good
+    case size
+    when "small" then 100
+    when "medium" then 250
+    when "large" then 1000
+    else 250
+    end
+
+### Example: IgnoreLiteralBranches: true
+    # good
+    case size
+    when "small" then SMALL_SIZE
+    when "medium" then MEDIUM_SIZE
+    when "large" then LARGE_SIZE
+    else MEDIUM_SIZE
+    end

--- a/config/contents/lint/duplicate_regexp_character_class_element.md
+++ b/config/contents/lint/duplicate_regexp_character_class_element.md
@@ -1,0 +1,15 @@
+This cop checks for duplicate elements in Regexp character classes.
+
+### Example:
+
+    # bad
+    r = /[xyx]/
+
+    # bad
+    r = /[0-9x0-9]/
+
+    # good
+    r = /[xy]/
+
+    # good
+    r = /[0-9x]/

--- a/config/contents/lint/else_layout.md
+++ b/config/contents/lint/else_layout.md
@@ -1,6 +1,10 @@
-This cop checks for odd else block layout - like
-having an expression on the same line as the else keyword,
+This cop checks for odd `else` block layout - like
+having an expression on the same line as the `else` keyword,
 which is usually a mistake.
+
+Its auto-correction tweaks layout to keep the syntax. So, this auto-correction
+is compatible correction for bad case syntax, but if your code makes a mistake
+with `elsif` and `else`, you will have to correct it manually.
 
 ### Example:
 
@@ -16,9 +20,18 @@ which is usually a mistake.
 
     # good
 
+    # This code is compatible with the bad case. It will be auto-corrected like this.
     if something
       # ...
     else
       do_this
+      do_that
+    end
+
+    # This code is incompatible with the bad case.
+    # If `do_this` is a condition, `elsif` should be used instead of `else`.
+    if something
+      # ...
+    elsif do_this
       do_that
     end

--- a/config/contents/lint/empty_block.md
+++ b/config/contents/lint/empty_block.md
@@ -1,0 +1,44 @@
+This cop checks for blocks without a body.
+Such empty blocks are typically an oversight or we should provide a comment
+be clearer what we're aiming for.
+
+Empty lambdas are ignored by default.
+
+### Example:
+    # bad
+    items.each { |item| }
+
+    # good
+    items.each { |item| puts item }
+
+### Example: AllowComments: true (default)
+    # good
+    items.each do |item|
+      # TODO: implement later (inner comment)
+    end
+
+    items.each { |item| } # TODO: implement later (inline comment)
+
+### Example: AllowComments: false
+    # bad
+    items.each do |item|
+      # TODO: implement later (inner comment)
+    end
+
+    items.each { |item| } # TODO: implement later (inline comment)
+
+### Example: AllowEmptyLambdas: true (default)
+    # good
+    allow(subject).to receive(:callable).and_return(-> {})
+
+    placeholder = lambda do
+    end
+    (callable || placeholder).call
+
+### Example: AllowEmptyLambdas: false
+    # bad
+    allow(subject).to receive(:callable).and_return(-> {})
+
+    placeholder = lambda do
+    end
+    (callable || placeholder).call

--- a/config/contents/lint/empty_class.md
+++ b/config/contents/lint/empty_class.md
@@ -1,0 +1,65 @@
+This cop checks for classes and metaclasses without a body.
+Such empty classes and metaclasses are typically an oversight or we should provide a comment
+to be clearer what we're aiming for.
+
+### Example:
+    # bad
+    class Foo
+    end
+
+    class Bar
+      class << self
+      end
+    end
+
+    class << obj
+    end
+
+    # good
+    class Foo
+      def do_something
+        # ... code
+      end
+    end
+
+    class Bar
+      class << self
+        attr_reader :bar
+      end
+    end
+
+    class << obj
+      attr_reader :bar
+    end
+
+### Example: AllowComments: false (default)
+    # bad
+    class Foo
+      # TODO: implement later
+    end
+
+    class Bar
+      class << self
+        # TODO: implement later
+      end
+    end
+
+    class << obj
+      # TODO: implement later
+    end
+
+### Example: AllowComments: true
+    # good
+    class Foo
+      # TODO: implement later
+    end
+
+    class Bar
+      class << self
+        # TODO: implement later
+      end
+    end
+
+    class << obj
+      # TODO: implement later
+    end

--- a/config/contents/lint/flip_flop.md
+++ b/config/contents/lint/flip_flop.md
@@ -1,5 +1,11 @@
-This cop looks for uses of flip-flop operator.
-flip-flop operator is deprecated since Ruby 2.6.0.
+This cop looks for uses of flip-flop operator
+based on the Ruby Style Guide.
+
+Here is the history of flip-flops in Ruby.
+flip-flop operator is deprecated in Ruby 2.6.0 and
+the deprecation has been reverted by Ruby 2.7.0 and
+backported to Ruby 2.6.
+See: https://bugs.ruby-lang.org/issues/5400
 
 ### Example:
     # bad

--- a/config/contents/lint/hash_compare_by_identity.md
+++ b/config/contents/lint/hash_compare_by_identity.md
@@ -1,0 +1,15 @@
+Prefer using `Hash#compare_by_identity` than using `object_id` for hash keys.
+
+This cop is marked as unsafe as a hash possibly can contain other keys
+besides `object_id`s.
+
+### Example:
+    # bad
+    hash = {}
+    hash[foo.object_id] = :bar
+    hash.key?(baz.object_id)
+
+    # good
+    hash = {}.compare_by_identity
+    hash[foo] = :bar
+    hash.key?(baz)

--- a/config/contents/lint/loop.md
+++ b/config/contents/lint/loop.md
@@ -1,5 +1,9 @@
 This cop checks for uses of `begin...end while/until something`.
 
+The cop is marked as unsafe because behaviour can change in some cases, including
+if a local variable inside the loop body is accessed outside of it, or if the
+loop body raises a `StopIteration` exception (which `Kernel#loop` rescues).
+
 ### Example:
 
     # bad

--- a/config/contents/lint/missing_super.md
+++ b/config/contents/lint/missing_super.md
@@ -1,6 +1,11 @@
 This cop checks for the presence of constructors and lifecycle callbacks
 without calls to `super`.
 
+This cop does not consider `method_missing` (and `respond_to_missing?`)
+because in some cases it makes sense to overtake what is considered a
+missing method. In other cases, the theoretical ideal handling could be
+challenging or verbose for no actual gain.
+
 ### Example:
     # bad
     class Employee < Person

--- a/config/contents/lint/nested_percent_literal.md
+++ b/config/contents/lint/nested_percent_literal.md
@@ -10,3 +10,16 @@ This cop checks for nested percent literals.
       valid_attributes: %i[name content],
       nested_attributes: %i[name content %i[incorrectly nested]]
     }
+
+    # good
+
+    # Neither is incompatible with the bad case, but probably the intended code.
+    attributes = {
+      valid_attributes: %i[name content],
+      nested_attributes: [:name, :content, %i[incorrectly nested]]
+    }
+
+    attributes = {
+      valid_attributes: %i[name content],
+      nested_attributes: [:name, :content, [:incorrectly, :nested]]
+    }

--- a/config/contents/lint/no_return_in_begin_end_blocks.md
+++ b/config/contents/lint/no_return_in_begin_end_blocks.md
@@ -1,0 +1,36 @@
+Checks for the presence of a `return` inside a `begin..end` block
+in assignment contexts.
+In this situation, the `return` will result in an exit from the current
+method, possibly leading to unexpected behavior.
+
+### Example:
+
+    # bad
+
+    @some_variable ||= begin
+      return some_value if some_condition_is_met
+
+      do_something
+    end
+
+### Example:
+
+    # good
+
+    @some_variable ||= begin
+      if some_condition_is_met
+        some_value
+      else
+        do_something
+      end
+    end
+
+    # good
+
+    some_variable = if some_condition_is_met
+                      return if another_condition_is_met
+
+                      some_value
+                    else
+                      do_something
+                    end

--- a/config/contents/lint/number_conversion.md
+++ b/config/contents/lint/number_conversion.md
@@ -2,6 +2,17 @@ This cop warns the usage of unsafe number conversions. Unsafe
 number conversion can cause unexpected error if auto type conversion
 fails. Cop prefer parsing with number class instead.
 
+Conversion with `Integer`, `Float`, etc. will raise an `ArgumentError`
+if given input that is not numeric (eg. an empty string), whereas
+`to_i`, etc. will try to convert regardless of input (`''.to_i => 0`).
+As such, this cop is disabled by default because it's not necessarily
+always correct to raise if a value is not numeric.
+
+NOTE: Some values cannot be converted properly using one of the `Kernel`
+method (for instance, `Time` and `DateTime` values are allowed by this
+cop by default). Similarly, Rails' duration methods do not work well
+with `Integer()` and can be ignored with `IgnoredMethods`.
+
 ### Example:
 
     # bad
@@ -15,3 +26,13 @@ fails. Cop prefer parsing with number class instead.
     Integer('10', 10)
     Float('10.2')
     Complex('10')
+
+### Example: IgnoredMethods: [minutes]
+
+    # good
+    10.minutes.to_i
+
+### Example: IgnoredClasses: [Time, DateTime] (default)
+
+    # good
+    Time.now.to_datetime.to_i

--- a/config/contents/lint/redundant_safe_navigation.md
+++ b/config/contents/lint/redundant_safe_navigation.md
@@ -1,0 +1,30 @@
+This cop checks for redundant safe navigation calls.
+`instance_of?`, `kind_of?`, `is_a?`, `eql?`, `respond_to?`, and `equal?` methods
+are checked by default. These are customizable with `AllowedMethods` option.
+
+This cop is marked as unsafe, because auto-correction can change the
+return type of the expression. An offending expression that previously
+could return `nil` will be auto-corrected to never return `nil`.
+
+In the example below, the safe navigation operator (`&.`) is unnecessary
+because `NilClass` has methods like `respond_to?` and `is_a?`.
+
+### Example:
+    # bad
+    do_something if attrs&.respond_to?(:[])
+
+    # good
+    do_something if attrs.respond_to?(:[])
+
+    # bad
+    while node&.is_a?(BeginNode)
+      node = node.parent
+    end
+
+    # good
+    while node.is_a?(BeginNode)
+      node = node.parent
+    end
+
+    # good - without `&.` this will always return `true`
+    foo&.respond_to?(:to_a)

--- a/config/contents/lint/redundant_splat_expansion.md
+++ b/config/contents/lint/redundant_splat_expansion.md
@@ -3,17 +3,41 @@ This cop checks for unneeded usages of splat expansion
 ### Example:
 
     # bad
-
     a = *[1, 2, 3]
     a = *'a'
     a = *1
+    ['a', 'b', *%w(c d e), 'f', 'g']
 
+    # good
+    c = [1, 2, 3]
+    a = *c
+    a, b = *c
+    a, *b = *c
+    a = *1..10
+    a = ['a']
+    ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+
+    # bad
+    do_something(*['foo', 'bar', 'baz'])
+
+    # good
+    do_something('foo', 'bar', 'baz')
+
+    # bad
     begin
       foo
     rescue *[StandardError, ApplicationError]
       bar
     end
 
+    # good
+    begin
+      foo
+    rescue StandardError, ApplicationError
+      bar
+    end
+
+    # bad
     case foo
     when *[1, 2, 3]
       bar
@@ -21,26 +45,20 @@ This cop checks for unneeded usages of splat expansion
       baz
     end
 
-### Example:
-
     # good
-
-    c = [1, 2, 3]
-    a = *c
-    a, b = *c
-    a, *b = *c
-    a = *1..10
-    a = ['a']
-
-    begin
-      foo
-    rescue StandardError, ApplicationError
-      bar
-    end
-
     case foo
     when 1, 2, 3
       bar
     else
       baz
     end
+
+### Example: AllowPercentLiteralArrayArgument: true (default)
+
+    # good
+    do_something(*%w[foo bar baz])
+
+### Example: AllowPercentLiteralArrayArgument: false
+
+    # bad
+    do_something(*%w[foo bar baz])

--- a/config/contents/lint/shadowing_outer_local_variable.md
+++ b/config/contents/lint/shadowing_outer_local_variable.md
@@ -3,6 +3,14 @@ in block arguments or block-local variables. This mirrors the warning
 given by `ruby -cw` prior to Ruby 2.6:
 "shadowing outer local variable - foo".
 
+NOTE: Shadowing of variables in block passed to `Ractor.new` is allowed
+because `Ractor` should not access outer variables.
+eg. following syle is encouraged:
+
+    worker_id, pipe = env
+    Ractor.new(worker_id, pipe) do |worker_id, pipe|
+    end
+
 ### Example:
 
     # bad

--- a/config/contents/lint/to_enum_arguments.md
+++ b/config/contents/lint/to_enum_arguments.md
@@ -1,0 +1,14 @@
+This cop ensures that `to_enum`/`enum_for`, called for the current method,
+has correct arguments.
+
+### Example:
+    # bad
+    def foo(x, y = 1)
+      return to_enum(__callee__, x) # `y` is missing
+    end
+
+    # good
+    def foo(x, y = 1)
+      return to_enum(__callee__, x, y)
+      # alternatives to `__callee__` are `__method__` and `:foo`
+    end

--- a/config/contents/lint/unexpected_block_arity.md
+++ b/config/contents/lint/unexpected_block_arity.md
@@ -1,0 +1,29 @@
+This cop checks for a block that is known to need more positional
+block arguments than are given (by default this is configured for
+`Enumerable` methods needing 2 arguments). Optional arguments are allowed,
+although they don't generally make sense as the default value will
+be used. Blocks that have no receiver, or take splatted arguments
+(ie. `*args`) are always accepted.
+
+Keyword arguments (including `**kwargs`) do not get counted towards
+this, as they are not used by the methods in question.
+
+NOTE: This cop matches for method names only and hence cannot tell apart
+methods with same name in different classes.
+
+Method names and their expected arity can be configured like this:
+
+Methods:
+    inject: 2
+    reduce: 2
+
+### Example:
+    # bad
+    values.reduce {}
+    values.min { |a| a }
+    values.sort { |a; b| a + b }
+
+    # good
+    values.reduce { |memo, obj| memo << obj }
+    values.min { |a, b| a <=> b }
+    values.sort { |*x| x[0] <=> x[1] }

--- a/config/contents/lint/unmodified_reduce_accumulator.md
+++ b/config/contents/lint/unmodified_reduce_accumulator.md
@@ -1,0 +1,59 @@
+Looks for `reduce` or `inject` blocks where the value returned (implicitly or
+explicitly) does not include the accumulator. A block is considered valid as
+long as at least one return value includes the accumulator.
+
+If the accumulator is not included in the return value, then the entire
+block will just return a transformation of the last element value, and
+could be rewritten as such without a loop.
+
+Also catches instances where an index of the accumulator is returned, as
+this may change the type of object being retained.
+
+NOTE: For the purpose of reducing false positives, this cop only flags
+returns in `reduce` blocks where the element is the only variable in
+the expression (since we will not be able to tell what other variables
+relate to via static analysis).
+
+### Example:
+
+    # bad
+    (1..4).reduce(0) do |acc, el|
+      el * 2
+    end
+
+    # bad, may raise a NoMethodError after the first iteration
+    %w(a b c).reduce({}) do |acc, letter|
+      acc[letter] = true
+    end
+
+    # good
+    (1..4).reduce(0) do |acc, el|
+      acc + el * 2
+    end
+
+    # good, element is returned but modified using the accumulator
+    values.reduce do |acc, el|
+      el << acc
+      el
+    end
+
+    # good, returns the accumulator instead of the index
+    %w(a b c).reduce({}) do |acc, letter|
+      acc[letter] = true
+      acc
+    end
+
+    # good, at least one branch returns the accumulator
+    values.reduce(nil) do |result, value|
+      break result if something?
+      value
+    end
+
+    # good, recursive
+    keys.reduce(self) { |result, key| result[key] }
+
+    # ignored as the return value cannot be determined
+    enum.reduce do |acc, el|
+      x = foo(acc, el)
+      bar(x)
+    end

--- a/config/contents/lint/unreachable_loop.md
+++ b/config/contents/lint/unreachable_loop.md
@@ -4,6 +4,12 @@ A loop that can never reach the second iteration is a possible error in the code
 In rare cases where only one iteration (or at most one iteration) is intended behavior,
 the code should be refactored to use `if` conditionals.
 
+NOTE: Block methods that are used with `Enumerable`s are considered to be loops.
+
+`IgnoredPatterns` can be used to match against the block receiver in order to allow
+code that would otherwise be registered as an offense (eg. `times` used not in an
+`Enumerable` context).
+
 ### Example:
     # bad
     while node
@@ -64,3 +70,11 @@ the code should be refactored to use `if` conditionals.
       end
       raise NotFoundError
     end
+
+    # bad
+    2.times { raise ArgumentError }
+
+### Example: IgnoredPatterns: [/(exactly|at_least|at_most)\(\d+\)\.times/] (default)
+
+    # good
+    exactly(2).times { raise StandardError }

--- a/config/contents/lint/useless_setter_call.md
+++ b/config/contents/lint/useless_setter_call.md
@@ -1,5 +1,6 @@
 This cop checks for setter call to local variable as the final
 expression of a function definition.
+Its auto-correction is marked as unsafe because return value will be changed.
 
 NOTE: There are edge cases in which the local variable references a
 value that is also accessible outside the local scope. This is not

--- a/config/contents/metrics/abc_size.md
+++ b/config/contents/metrics/abc_size.md
@@ -2,3 +2,24 @@ This cop checks that the ABC size of methods is not higher than the
 configured maximum. The ABC size is based on assignments, branches
 (method calls), and conditions. See http://c2.com/cgi/wiki?AbcMetric
 and https://en.wikipedia.org/wiki/ABC_Software_Metric.
+
+You can have repeated "attributes" calls count as a single "branch".
+For this purpose, attributes are any method with no argument; no attempt
+is meant to distinguish actual `attr_reader` from other methods.
+
+### Example: CountRepeatedAttributes: false (default is true)
+
+     # `model` and `current_user`, refenced 3 times each,
+     # are each counted as only 1 branch each if
+     # `CountRepeatedAttributes` is set to 'false'
+
+     def search
+       @posts = model.active.visible_by(current_user)
+                 .search(params[:q])
+       @posts = model.some_process(@posts, current_user)
+       @posts = model.another_process(@posts, current_user)
+
+       render 'pages/search/page'
+     end
+
+This cop also takes into account `IgnoredMethods` (defaults to `[]`)

--- a/config/contents/metrics/block_length.md
+++ b/config/contents/metrics/block_length.md
@@ -7,6 +7,10 @@ You can set literals you want to fold with `CountAsOne`.
 Available are: 'array', 'hash', and 'heredoc'. Each literal
 will be counted as one line regardless of its actual size.
 
+
+NOTE: The `ExcludedMethods` configuration is deprecated and only kept
+for backwards compatibility. Please use `IgnoredMethods` instead.
+
 ### Example: CountAsOne: ['array', 'heredoc']
 
     something do
@@ -24,3 +28,5 @@ will be counted as one line regardless of its actual size.
         content.
       HEREDOC
     end                 # 5 points
+
+NOTE: This cop does not apply for `Struct` definitions.

--- a/config/contents/metrics/class_length.md
+++ b/config/contents/metrics/class_length.md
@@ -23,3 +23,6 @@ will be counted as one line regardless of its actual size.
         content.
       HEREDOC
     end                 # 5 points
+
+
+NOTE: This cop also applies for `Struct` definitions.

--- a/config/contents/metrics/method_length.md
+++ b/config/contents/metrics/method_length.md
@@ -6,6 +6,9 @@ You can set literals you want to fold with `CountAsOne`.
 Available are: 'array', 'hash', and 'heredoc'. Each literal
 will be counted as one line regardless of its actual size.
 
+NOTE: The `ExcludedMethods` configuration is deprecated and only kept
+for backwards compatibility. Please use `IgnoredMethods` instead.
+
 ### Example: CountAsOne: ['array', 'heredoc']
 
     def m

--- a/config/contents/metrics/parameter_lists.md
+++ b/config/contents/metrics/parameter_lists.md
@@ -1,3 +1,46 @@
 This cop checks for methods with too many parameters.
+
 The maximum number of parameters is configurable.
-Keyword arguments can optionally be excluded from the total count.
+Keyword arguments can optionally be excluded from the total count,
+as they add less complexity than positional or optional parameters.
+
+### Example: Max: 3
+    # good
+    def foo(a, b, c = 1)
+    end
+
+### Example: Max: 2
+    # bad
+    def foo(a, b, c = 1)
+    end
+
+### Example: CountKeywordArgs: true (default)
+    # counts keyword args towards the maximum
+
+    # bad (assuming Max is 3)
+    def foo(a, b, c, d: 1)
+    end
+
+    # good (assuming Max is 3)
+    def foo(a, b, c: 1)
+    end
+
+### Example: CountKeywordArgs: false
+    # don't count keyword args towards the maximum
+
+    # good (assuming Max is 3)
+    def foo(a, b, c, d: 1)
+    end
+
+This cop also checks for the maximum number of optional parameters.
+This can be configured using the `MaxOptionalParameters` config option.
+
+### Example: MaxOptionalParameters: 3 (default)
+    # good
+    def foo(a = 1, b = 2, c = 3)
+    end
+
+### Example: MaxOptionalParameters: 2
+    # bad
+    def foo(a = 1, b = 2, c = 3)
+    end

--- a/config/contents/naming/accessor_method_name.md
+++ b/config/contents/naming/accessor_method_name.md
@@ -1,4 +1,10 @@
-This cop makes sure that accessor methods are named properly.
+This cop makes sure that accessor methods are named properly. Applies
+to both instance and class methods.
+
+NOTE: Offenses are only registered for methods with the expected
+arity. Getters (`get_attribute`) must have no arguments to be
+registered, and setters (`set_attribute(value)`) must have exactly
+one.
 
 ### Example:
     # bad
@@ -15,4 +21,12 @@ This cop makes sure that accessor methods are named properly.
 
     # good
     def attribute
+    end
+
+    # accepted, incorrect arity for getter
+    def get_value(attr)
+    end
+
+    # accepted, incorrect arity for setter
+    def set_value
     end

--- a/config/contents/naming/memoized_instance_variable_name.md
+++ b/config/contents/naming/memoized_instance_variable_name.md
@@ -1,5 +1,7 @@
 This cop checks for memoized methods whose instance variable name
-does not match the method name.
+does not match the method name. Applies to both regular methods
+(defined with `def`) and dynamic methods (defined with
+`define_method` or `define_singleton_method`).
 
 This cop can be configured with the EnforcedStyleForLeadingUnderscores
 directive. It can be configured to allow for memoized instance variables
@@ -13,6 +15,11 @@ be set or referenced outside of the memoization method.
     # not `@foo`. This can cause confusion and bugs.
     def foo
       @something ||= calculate_expensive_thing
+    end
+
+    def foo
+      return @something if defined?(@something)
+      @something = calculate_expensive_thing
     end
 
     # good
@@ -38,6 +45,17 @@ be set or referenced outside of the memoization method.
       @foo ||= calculate_expensive_thing(helper_variable)
     end
 
+    # good
+    define_method(:foo) do
+      @foo ||= calculate_expensive_thing
+    end
+
+    # good
+    define_method(:foo) do
+      return @foo if defined?(@foo)
+      @foo = calculate_expensive_thing
+    end
+
 ### Example: EnforcedStyleForLeadingUnderscores: required
     # bad
     def foo
@@ -49,6 +67,11 @@ be set or referenced outside of the memoization method.
       @foo ||= calculate_expensive_thing
     end
 
+    def foo
+      return @foo if defined?(@foo)
+      @foo = calculate_expensive_thing
+    end
+
     # good
     def foo
       @_foo ||= calculate_expensive_thing
@@ -57,6 +80,22 @@ be set or referenced outside of the memoization method.
     # good
     def _foo
       @_foo ||= calculate_expensive_thing
+    end
+
+    def foo
+      return @_foo if defined?(@_foo)
+      @_foo = calculate_expensive_thing
+    end
+
+    # good
+    define_method(:foo) do
+      @_foo ||= calculate_expensive_thing
+    end
+
+    # good
+    define_method(:foo) do
+      return @_foo if defined?(@_foo)
+      @_foo = calculate_expensive_thing
     end
 
 ### Example: EnforcedStyleForLeadingUnderscores :optional
@@ -77,5 +116,21 @@ be set or referenced outside of the memoization method.
 
     # good
     def _foo
+      @_foo ||= calculate_expensive_thing
+    end
+
+    # good
+    def foo
+      return @_foo if defined?(@_foo)
+      @_foo = calculate_expensive_thing
+    end
+
+    # good
+    define_method(:foo) do
+      @foo ||= calculate_expensive_thing
+    end
+
+    # good
+    define_method(:foo) do
       @_foo ||= calculate_expensive_thing
     end

--- a/config/contents/naming/variable_number.md
+++ b/config/contents/naming/variable_number.md
@@ -2,33 +2,91 @@ This cop makes sure that all numbered variables use the
 configured style, snake_case, normalcase, or non_integer,
 for their numbering.
 
+Additionally, `CheckMethodNames` and `CheckSymbols` configuration options
+can be used to specify whether method names and symbols should be checked.
+Both are enabled by default.
+
 ### Example: EnforcedStyle: snake_case
     # bad
-
+    :some_sym1
     variable1 = 1
 
-    # good
+    def some_method1; end
 
+    def some_method_1(arg1); end
+
+    # good
+    :some_sym_1
     variable_1 = 1
+
+    def some_method_1; end
+
+    def some_method_1(arg_1); end
 
 ### Example: EnforcedStyle: normalcase (default)
     # bad
-
+    :some_sym_1
     variable_1 = 1
 
-    # good
+    def some_method_1; end
 
+    def some_method1(arg_1); end
+
+    # good
+    :some_sym1
     variable1 = 1
+
+    def some_method1; end
+
+    def some_method1(arg1); end
 
 ### Example: EnforcedStyle: non_integer
     # bad
+    :some_sym1
+    :some_sym_1
 
     variable1 = 1
-
     variable_1 = 1
 
+    def some_method1; end
+
+    def some_method_1; end
+
+    def some_methodone(arg1); end
+    def some_methodone(arg_1); end
+
     # good
+    :some_symone
+    :some_sym_one
 
     variableone = 1
-
     variable_one = 1
+
+    def some_methodone; end
+
+    def some_method_one; end
+
+    def some_methodone(argone); end
+    def some_methodone(arg_one); end
+
+    # In the following examples, we assume `EnforcedStyle: normalcase` (default).
+
+### Example: CheckMethodNames: true (default)
+    # bad
+    def some_method_1; end
+
+### Example: CheckMethodNames: false
+    # good
+    def some_method_1; end
+
+### Example: CheckSymbols: true (default)
+    # bad
+    :some_sym_1
+
+### Example: CheckSymbols: false
+    # good
+    :some_sym_1
+
+### Example: AllowedIdentifier: [capture3]
+    # good
+    expect(Open3).to receive(:capture3)

--- a/config/contents/security/open.md
+++ b/config/contents/security/open.md
@@ -1,14 +1,15 @@
-This cop checks for the use of `Kernel#open`.
+This cop checks for the use of `Kernel#open` and `URI.open`.
 
-`Kernel#open` enables not only file access but also process invocation
-by prefixing a pipe symbol (e.g., `open("| ls")`). So, it may lead to
-a serious security risk by using variable input to the argument of
-`Kernel#open`. It would be better to use `File.open`, `IO.popen` or
-`URI#open` explicitly.
+`Kernel#open` and `URI.open` enable not only file access but also process
+invocation by prefixing a pipe symbol (e.g., `open("| ls")`).
+So, it may lead to a serious security risk by using variable input to
+the argument of `Kernel#open` and `URI.open`. It would be better to use
+`File.open`, `IO.popen` or `URI.parse#open` explicitly.
 
 ### Example:
     # bad
     open(something)
+    URI.open(something)
 
     # good
     File.open(something)

--- a/config/contents/style/accessor_grouping.md
+++ b/config/contents/style/accessor_grouping.md
@@ -2,6 +2,9 @@ This cop checks for grouping of accessors in `class` and `module` bodies.
 By default it enforces accessors to be placed in grouped declarations,
 but it can be configured to enforce separating them in multiple declarations.
 
+NOTE: `Sorbet` is not compatible with "grouped" style. Consider "separated" style
+or disabling this cop.
+
 ### Example: EnforcedStyle: grouped (default)
     # bad
     class Foo

--- a/config/contents/style/arguments_forwarding.md
+++ b/config/contents/style/arguments_forwarding.md
@@ -1,0 +1,34 @@
+In Ruby 2.7, arguments forwarding has been added.
+
+This cop identifies places where `do_something(*args, &block)`
+can be replaced by `do_something(...)`.
+
+### Example:
+    # bad
+    def foo(*args, &block)
+      bar(*args, &block)
+    end
+
+    # bad
+    def foo(*args, **kwargs, &block)
+      bar(*args, **kwargs, &block)
+    end
+
+    # good
+    def foo(...)
+      bar(...)
+    end
+
+### Example: AllowOnlyRestArgument: true (default)
+    # good
+    def foo(*args)
+      bar(*args)
+    end
+
+### Example: AllowOnlyRestArgument: false
+    # bad
+    # The following code can replace the arguments with `...`,
+    # but it will change the behavior. Because `...` forwards block also.
+    def foo(*args)
+      bar(*args)
+    end

--- a/config/contents/style/class_equality_comparison.md
+++ b/config/contents/style/class_equality_comparison.md
@@ -1,0 +1,12 @@
+This cop enforces the use of `Object#instance_of?` instead of class comparison
+for equality.
+
+### Example:
+    # bad
+    var.class == Date
+    var.class.equal?(Date)
+    var.class.eql?(Date)
+    var.class.name == 'Date'
+
+    # good
+    var.instance_of?(Date)

--- a/config/contents/style/collection_compact.md
+++ b/config/contents/style/collection_compact.md
@@ -1,0 +1,23 @@
+This cop checks for places where custom logic on rejection nils from arrays
+and hashes can be replaced with `{Array,Hash}#{compact,compact!}`.
+
+It is marked as unsafe by default because false positives may occur in the
+nil check of block arguments to the receiver object.
+For example, `[[1, 2], [3, nil]].reject { |first, second| second.nil? }`
+and `[[1, 2], [3, nil]].compact` are not compatible. This will work fine
+when the receiver is a hash object.
+
+### Example:
+    # bad
+    array.reject { |e| e.nil? }
+    array.select { |e| !e.nil? }
+
+    # good
+    array.compact
+
+    # bad
+    hash.reject! { |k, v| v.nil? }
+    hash.select! { |k, v| !v.nil? }
+
+    # good
+    hash.compact!

--- a/config/contents/style/combinable_loops.md
+++ b/config/contents/style/combinable_loops.md
@@ -43,3 +43,9 @@ a state that the second loop depends on; these two aren't combinable.
         do_something_else(item)
       end
     end
+
+    # good
+    def method
+      each_slice(2) { |slice| do_something(slice) }
+      each_slice(3) { |slice| do_something(slice) }
+    end

--- a/config/contents/style/comment_annotation.md
+++ b/config/contents/style/comment_annotation.md
@@ -1,6 +1,12 @@
 This cop checks that comment annotation keywords are written according
 to guidelines.
 
+NOTE: With a multiline comment block (where each line is only a
+comment), only the first line will be able to register an offense, even
+if an annotation keyword starts another line. This is done to prevent
+incorrect registering of keywords (eg. `review`) inside a paragraph as an
+annotation.
+
 ### Example:
     # bad
     # TODO make better

--- a/config/contents/style/commented_keyword.md
+++ b/config/contents/style/commented_keyword.md
@@ -1,9 +1,12 @@
 This cop checks for comments put on the same line as some keywords.
-These keywords are: `begin`, `class`, `def`, `end`, `module`.
+These keywords are: `class`, `module`, `def`, `begin`, `end`.
 
 Note that some comments
 (`:nodoc:`, `:yields:`, `rubocop:disable` and `rubocop:todo`)
 are allowed.
+
+Auto-correction removes comments from `end` keyword and keeps comments
+for `class`, `module`, `def` and `begin` above the keyword.
 
 ### Example:
     # bad

--- a/config/contents/style/document_dynamic_eval_definition.md
+++ b/config/contents/style/document_dynamic_eval_definition.md
@@ -1,0 +1,71 @@
+When using `class_eval` (or other `eval`) with string interpolation,
+add a comment block showing its appearance if interpolated (a practice used in Rails code).
+
+### Example:
+    # from activesupport/lib/active_support/core_ext/string/output_safety.rb
+
+    # bad
+    UNSAFE_STRING_METHODS.each do |unsafe_method|
+      if 'String'.respond_to?(unsafe_method)
+        class_eval <<-EOT, __FILE__, __LINE__ + 1
+          def #{unsafe_method}(*params, &block)
+            to_str.#{unsafe_method}(*params, &block)
+          end
+
+          def #{unsafe_method}!(*params)
+            @dirty = true
+            super
+          end
+        EOT
+      end
+    end
+
+    # good, inline comments in heredoc
+    UNSAFE_STRING_METHODS.each do |unsafe_method|
+      if 'String'.respond_to?(unsafe_method)
+        class_eval <<-EOT, __FILE__, __LINE__ + 1
+          def #{unsafe_method}(*params, &block)       # def capitalize(*params, &block)
+            to_str.#{unsafe_method}(*params, &block)  #   to_str.capitalize(*params, &block)
+          end                                         # end
+
+          def #{unsafe_method}!(*params)              # def capitalize!(*params)
+            @dirty = true                             #   @dirty = true
+            super                                     #   super
+          end                                         # end
+        EOT
+      end
+    end
+
+    # good, block comments in heredoc
+    class_eval <<-EOT, __FILE__, __LINE__ + 1
+      # def capitalize!(*params)
+      #   @dirty = true
+      #   super
+      # end
+
+      def #{unsafe_method}!(*params)
+        @dirty = true
+        super
+      end
+    EOT
+
+    # good, block comments before heredoc
+    class_eval(
+      # def capitalize!(*params)
+      #   @dirty = true
+      #   super
+      # end
+
+      <<-EOT, __FILE__, __LINE__ + 1
+        def #{unsafe_method}!(*params)
+          @dirty = true
+          super
+        end
+      EOT
+    )
+
+    # bad - interpolated string without comment
+    class_eval("def #{unsafe_method}!(*params); end")
+
+    # good - with inline comment or replace it with block comment using heredoc
+    class_eval("def #{unsafe_method}!(*params); end # def capitalize!(*params); end")

--- a/config/contents/style/documentation.md
+++ b/config/contents/style/documentation.md
@@ -49,3 +49,8 @@ same for all its children.
       module Namespace
         Public = Class.new
       end
+
+      # Macro calls
+      module Namespace
+        extend Foo
+      end

--- a/config/contents/style/format_string_token.md
+++ b/config/contents/style/format_string_token.md
@@ -28,7 +28,28 @@ to encoded URLs or Date/Time formatting strings.
 
     # bad
     format('%<greeting>s', greeting: 'Hello')
-    format('%{greeting}', 'Hello')
+    format('%{greeting}', greeting: 'Hello')
 
     # good
     format('%s', 'Hello')
+
+It is allowed to contain unannotated token
+if the number of them is less than or equals to
+`MaxUnannotatedPlaceholdersAllowed`.
+
+### Example: MaxUnannotatedPlaceholdersAllowed: 0
+
+    # bad
+    format('%06d', 10)
+    format('%s %s.', 'Hello', 'world')
+
+    # good
+    format('%<number>06d', number: 10)
+
+### Example: MaxUnannotatedPlaceholdersAllowed: 1 (default)
+
+    # bad
+    format('%s %s.', 'Hello', 'world')
+
+    # good
+    format('%06d', 10)

--- a/config/contents/style/hash_except.md
+++ b/config/contents/style/hash_except.md
@@ -1,0 +1,19 @@
+This cop checks for usages of `Hash#reject`, `Hash#select`, and `Hash#filter` methods
+that can be replaced with `Hash#except` method.
+
+This cop should only be enabled on Ruby version 3.0 or higher.
+(`Hash#except` was added in Ruby 3.0.)
+
+For safe detection, it is limited to commonly used string and symbol comparisons
+when used `==`.
+And do not check `Hash#delete_if` and `Hash#keep_if` to change receiver object.
+
+### Example:
+
+    # bad
+    {foo: 1, bar: 2, baz: 3}.reject {|k, v| k == :bar }
+    {foo: 1, bar: 2, baz: 3}.select {|k, v| k != :bar }
+    {foo: 1, bar: 2, baz: 3}.filter {|k, v| k != :bar }
+
+    # good
+    {foo: 1, bar: 2, baz: 3}.except(:bar)

--- a/config/contents/style/identical_conditional_branches.md
+++ b/config/contents/style/identical_conditional_branches.md
@@ -1,5 +1,10 @@
-This cop checks for identical lines at the beginning or end of
-each branch of a conditional statement.
+This cop checks for identical expressions at the beginning or end of
+each branch of a conditional expression. Such expressions should normally
+be placed outside the conditional expression - before or after it.
+
+NOTE: The cop is poorly named and some people might think that it actually
+checks for duplicated conditional branches. The name will probably be changed
+in a future major RuboCop release.
 
 ### Example:
     # bad

--- a/config/contents/style/if_unless_modifier.md
+++ b/config/contents/style/if_unless_modifier.md
@@ -16,12 +16,16 @@ cop. The tab size is configured in the `IndentationWidth` of the
       Foo.do_something
     end
 
-    do_something_in_a_method_with_a_long_name(arg) if long_condition
+    do_something_with_a_long_name(arg) if long_condition_that_prevents_code_fit_on_single_line
 
     # good
     do_stuff(bar) if condition
     Foo.do_something unless qux.empty?
 
-    if long_condition
-      do_something_in_a_method_with_a_long_name(arg)
+    if long_condition_that_prevents_code_fit_on_single_line
+      do_something_with_a_long_name(arg)
+    end
+
+    if short_condition # a long comment that makes it too long if it were just a single line
+      do_something
     end

--- a/config/contents/style/infinite_loop.md
+++ b/config/contents/style/infinite_loop.md
@@ -1,5 +1,9 @@
 Use `Kernel#loop` for infinite loops.
 
+This cop is marked as unsafe as the rule does not necessarily
+apply if the body might raise a `StopIteration` exception; contrary to
+other infinite loops, `Kernel#loop` silently rescues that and returns `nil`.
+
 ### Example:
     # bad
     while true

--- a/config/contents/style/keyword_parameters_order.md
+++ b/config/contents/style/keyword_parameters_order.md
@@ -15,3 +15,13 @@ and optional parameters at the end.
     def some_method(second:, first: false, third: 10)
       # body omitted
     end
+
+    # bad
+    do_something do |first: false, second:, third: 10|
+      # body omitted
+    end
+
+    # good
+    do_something do |second:, first: false, third: 10|
+      # body omitted
+    end

--- a/config/contents/style/method_call_with_args_parentheses.md
+++ b/config/contents/style/method_call_with_args_parentheses.md
@@ -35,6 +35,9 @@ options.
       to `true` allows the presence of parentheses in such a method call
       even with arguments.
 
+NOTE: Parens are required around a method with arguments when inside an
+endless method definition (>= Ruby 3.0).
+
 ### Example: EnforcedStyle: require_parentheses (default)
 
     # bad

--- a/config/contents/style/method_def_parentheses.md
+++ b/config/contents/style/method_def_parentheses.md
@@ -1,6 +1,9 @@
 This cop checks for parentheses around the arguments in method
 definitions. Both instance and class/singleton methods are checked.
 
+This cop does not consider endless methods, since parentheses are
+always required for them.
+
 ### Example: EnforcedStyle: require_parentheses (default)
     # The `require_parentheses` style requires method definitions
     # to always use parentheses

--- a/config/contents/style/multiple_comparison.md
+++ b/config/contents/style/multiple_comparison.md
@@ -1,5 +1,8 @@
 This cop checks against comparing a variable with multiple items, where
-`Array#include?` could be used instead to avoid code repetition.
+`Array#include?`, `Set#include?` or a `case` could be used instead
+to avoid code repetition.
+It accepts comparisons of multiple method calls to avoid unnecessary method calls
+by default. It can be configured by `AllowMethodComparison` option.
 
 ### Example:
     # bad
@@ -9,3 +12,26 @@ This cop checks against comparing a variable with multiple items, where
     # good
     a = 'a'
     foo if ['a', 'b', 'c'].include?(a)
+
+    VALUES = Set['a', 'b', 'c'].freeze
+    # elsewhere...
+    foo if VALUES.include?(a)
+
+    case foo
+    when 'a', 'b', 'c' then foo
+    # ...
+    end
+
+    # accepted (but consider `case` as above)
+    foo if a == b.lightweight || a == b.heavyweight
+
+### Example: AllowMethodComparison: true (default)
+    # good
+    foo if a == b.lightweight || a == b.heavyweight
+
+### Example: AllowMethodComparison: false
+    # bad
+    foo if a == b.lightweight || a == b.heavyweight
+
+    # good
+    foo if [b.lightweight, b.heavyweight].include?(a)

--- a/config/contents/style/mutable_constant.md
+++ b/config/contents/style/mutable_constant.md
@@ -9,6 +9,8 @@ frozen objects so there is a decent chance of getting some false
 positives. Luckily, there is no harm in freezing an already
 frozen object.
 
+NOTE: Regexp and Range literals are frozen objects since Ruby 3.0.
+
 ### Example: EnforcedStyle: literals (default)
     # bad
     CONST = [1, 2, 3]

--- a/config/contents/style/negated_if_else_condition.md
+++ b/config/contents/style/negated_if_else_condition.md
@@ -1,0 +1,23 @@
+This cop checks for uses of `if-else` and ternary operators with a negated condition
+which can be simplified by inverting condition and swapping branches.
+
+### Example:
+    # bad
+    if !x
+      do_something
+    else
+      do_something_else
+    end
+
+    # good
+    if x
+      do_something_else
+    else
+      do_something
+    end
+
+    # bad
+    !x ? do_something : do_something_else
+
+    # good
+    x ? do_something_else : do_something

--- a/config/contents/style/nil_lambda.md
+++ b/config/contents/style/nil_lambda.md
@@ -1,0 +1,18 @@
+This cop checks for lambdas that always return nil, which can be replaced
+with an empty lambda instead.
+
+### Example:
+    # bad
+    -> { nil }
+
+    lambda do
+      next nil
+    end
+
+    # good
+    -> {}
+
+    lambda do
+    end
+
+    -> (x) { nil if x }

--- a/config/contents/style/perl_backrefs.md
+++ b/config/contents/style/perl_backrefs.md
@@ -1,5 +1,6 @@
 This cop looks for uses of Perl-style regexp match
-backreferences like $1, $2, etc.
+backreferences and their English versions like
+$1, $2, $&, &+, $MATCH, $PREMATCH, etc.
 
 ### Example:
     # bad

--- a/config/contents/style/raise_args.md
+++ b/config/contents/style/raise_args.md
@@ -8,22 +8,29 @@ The exploded style works identically, but with the addition that it
 will also suggest constructing error objects when the exception is
 passed multiple arguments.
 
+The exploded style has an `AllowedCompactTypes` configuration
+option that takes an Array of exception name Strings.
+
 ### Example: EnforcedStyle: exploded (default)
     # bad
-    raise StandardError.new("message")
+    raise StandardError.new('message')
 
     # good
-    raise StandardError, "message"
-    fail "message"
+    raise StandardError, 'message'
+    fail 'message'
     raise MyCustomError.new(arg1, arg2, arg3)
     raise MyKwArgError.new(key1: val1, key2: val2)
 
+    # With `AllowedCompactTypes` set to ['MyWrappedError']
+    raise MyWrappedError.new(obj)
+    raise MyWrappedError.new(obj), 'message'
+
 ### Example: EnforcedStyle: compact
     # bad
-    raise StandardError, "message"
+    raise StandardError, 'message'
     raise RuntimeError, arg1, arg2, arg3
 
     # good
-    raise StandardError.new("message")
+    raise StandardError.new('message')
     raise MyCustomError.new(arg1, arg2, arg3)
-    fail "message"
+    fail 'message'

--- a/config/contents/style/redundant_argument.md
+++ b/config/contents/style/redundant_argument.md
@@ -1,0 +1,37 @@
+This cop checks for a redundant argument passed to certain methods.
+
+Limitations:
+
+1. This cop matches for method names only and hence cannot tell apart
+     methods with same name in different classes.
+2. This cop is limited to methods with single parameter.
+3. This cop is unsafe if certain special global variables (e.g. `$;`, `$/`) are set.
+     That depends on the nature of the target methods, of course.
+
+Method names and their redundant arguments can be configured like this:
+
+Methods:
+    join: ''
+    split: ' '
+    chomp: "\n"
+    chomp!: "\n"
+    foo: 2
+
+### Example:
+    # bad
+    array.join('')
+    [1, 2, 3].join("")
+    string.split(" ")
+    "first\nsecond".split(" ")
+    string.chomp("\n")
+    string.chomp!("\n")
+    A.foo(2)
+
+    # good
+    array.join
+    [1, 2, 3].join
+    string.split
+    "first second".split
+    string.chomp
+    string.chomp!
+    A.foo

--- a/config/contents/style/redundant_begin.md
+++ b/config/contents/style/redundant_begin.md
@@ -23,6 +23,14 @@ Currently it checks for code like this:
     end
 
     # bad
+    begin
+      do_something
+    end
+
+    # good
+    do_something
+
+    # bad
     # When using Ruby 2.5 or later.
     do_something do
       begin

--- a/config/contents/style/redundant_freeze.md
+++ b/config/contents/style/redundant_freeze.md
@@ -1,4 +1,6 @@
-This cop check for uses of Object#freeze on immutable objects.
+This cop check for uses of `Object#freeze` on immutable objects.
+
+NOTE: Regexp and Range literals are frozen objects since Ruby 3.0.
 
 ### Example:
     # bad

--- a/config/contents/style/redundant_regexp_character_class.md
+++ b/config/contents/style/redundant_regexp_character_class.md
@@ -14,5 +14,11 @@ This cop checks for unnecessary single-element Regexp character classes.
     # good
     r = /\s/
 
+    # bad
+    r = %r{/[b]}
+
+    # good
+    r = %r{/b}
+
     # good
     r = /[ab]/

--- a/config/contents/style/single_line_methods.md
+++ b/config/contents/style/single_line_methods.md
@@ -1,6 +1,8 @@
 This cop checks for single-line method definitions that contain a body.
 It will accept single-line methods with no body.
 
+Endless methods added in Ruby 3.0 are also accepted by this cop.
+
 ### Example:
     # bad
     def some_method; body end
@@ -10,6 +12,7 @@ It will accept single-line methods with no body.
     # good
     def self.resource_class=(klass); end
     def @table.columns; end
+    def some_method() = body
 
 ### Example: AllowIfMethodIsEmpty: true (default)
     # good

--- a/config/contents/style/special_global_vars.md
+++ b/config/contents/style/special_global_vars.md
@@ -21,10 +21,6 @@ This cop looks for uses of Perl-style global variables.
     puts $LAST_MATCH_INFO
     puts $IGNORECASE
     puts $ARGV # or ARGV
-    puts $MATCH
-    puts $PREMATCH
-    puts $POSTMATCH
-    puts $LAST_PAREN_MATCH
 
 ### Example: EnforcedStyle: use_perl_names
     # good
@@ -46,7 +42,3 @@ This cop looks for uses of Perl-style global variables.
     puts $~
     puts $=
     puts $*
-    puts $&
-    puts $`
-    puts $'
-    puts $+

--- a/config/contents/style/static_class.md
+++ b/config/contents/style/static_class.md
@@ -1,0 +1,38 @@
+This cop checks for places where classes with only class methods can be
+replaced with a module. Classes should be used only when it makes sense to create
+instances out of them.
+
+This cop is marked as unsafe, because it is possible that this class is a parent
+for some other subclass, monkey-patched with instance methods or
+a dummy instance is instantiated from it somewhere.
+
+### Example:
+    # bad
+    class SomeClass
+      def self.some_method
+        # body omitted
+      end
+
+      def self.some_other_method
+        # body omitted
+      end
+    end
+
+    # good
+    module SomeModule
+      module_function
+
+      def some_method
+        # body omitted
+      end
+
+      def some_other_method
+        # body omitted
+      end
+    end
+
+    # good - has instance method
+    class SomeClass
+      def instance_method; end
+      def self.class_method; end
+    end

--- a/config/contents/style/string_concatenation.md
+++ b/config/contents/style/string_concatenation.md
@@ -6,6 +6,10 @@ more complex cases where the resulting code would be harder to read.
 In those cases, it might be useful to extract statements to local
 variables or methods which you can then interpolate in a string.
 
+NOTE: When concatenation between two strings is broken over multiple
+lines, this cop does not register an offense; instead,
+`Style/LineEndConcatenation` will pick up the offense if enabled.
+
 ### Example:
     # bad
     email_with_name = user.name + ' <' + user.email + '>'
@@ -13,3 +17,7 @@ variables or methods which you can then interpolate in a string.
     # good
     email_with_name = "#{user.name} <#{user.email}>"
     email_with_name = format('%s <%s>', user.name, user.email)
+
+    # accepted, line-end concatenation
+    name = 'First' +
+      'Last'

--- a/config/contents/style/swap_values.md
+++ b/config/contents/style/swap_values.md
@@ -1,0 +1,12 @@
+This cop enforces the use of shorthand-style swapping of 2 variables.
+Its autocorrection is marked as unsafe, because it can erroneously remove
+the temporary variable which is used later.
+
+### Example:
+    # bad
+    tmp = x
+    x = y
+    y = tmp
+
+    # good
+    x, y = y, x

--- a/config/contents/style/symbol_proc.md
+++ b/config/contents/style/symbol_proc.md
@@ -3,6 +3,7 @@ Use symbols as procs when possible.
 ### Example:
     # bad
     something.map { |s| s.upcase }
+    something.map { _1.upcase }
 
     # good
     something.map(&:upcase)

--- a/config/contents/style/while_until_modifier.md
+++ b/config/contents/style/while_until_modifier.md
@@ -19,3 +19,12 @@ configured in the `Layout/LineLength` cop.
 
     # good
     x += 1 until x > 10
+
+### Example:
+    # bad
+    x += 100 while x < 500 # a long comment that makes code too long if it were a single line
+
+    # good
+    while x < 500 # a long comment that makes code too long if it were a single line
+      x += 100
+    end

--- a/lib/cc/engine/category_parser.rb
+++ b/lib/cc/engine/category_parser.rb
@@ -26,8 +26,7 @@ module CC
         "Rails/HasAndBelongsToMany" => "Style",
         "Rails/TimeZone" => "Style",
         "Rails/Validation" => "Style",
-        "Style" => "Style",
-        "Migrations/RemoveIndex" => "Performance",
+        "Style" => "Style"
       }.freeze
 
       attr_reader :cop_name

--- a/lib/rubocop/config_patch.rb
+++ b/lib/rubocop/config_patch.rb
@@ -3,7 +3,7 @@
 require "rubocop/config"
 
 module RuboCopConfigRescue
-  def reject_obsolete_cops_and_parameters
+  def reject_obsolete!
     super
   rescue RuboCop::ValidationError => e
     warn e.message

--- a/spec/rubocop/config_patch_spec.rb
+++ b/spec/rubocop/config_patch_spec.rb
@@ -33,6 +33,7 @@ module CC::Engine
         The `Layout/AlignArguments` cop has been renamed to `Layout/ArgumentAlignment`.
         (obsolete configuration found in .rubocop.yml, please update it)
         unrecognized cop Layout/AlignArguments found in .rubocop.yml
+        Did you mean `Layout/HashAlignment`?
       EOM
 
       expect { config.validate }.to output(expected).to_stderr
@@ -50,9 +51,10 @@ module CC::Engine
 
 
       expected = <<~EOM
-        The `Style/TrailingComma` cop has been removed. Please use `Style/TrailingCommaInArguments`, `Style/TrailingCommaInArrayLiteral`, and/or `Style/TrailingCommaInHashLiteral` instead.
+        The `Style/TrailingComma` cop has been removed. Please use `Style/TrailingCommaInArguments`, `Style/TrailingCommaInArrayLiteral` and/or `Style/TrailingCommaInHashLiteral` instead.
         (obsolete configuration found in .rubocop.yml, please update it)
         unrecognized cop Style/TrailingComma found in .rubocop.yml
+        Did you mean `Style/TrailingCommaInArguments`?
       EOM
 
       expect { config.validate }.to output(expected).to_stderr

--- a/spec/support/config_upgrader_rubocop.yml
+++ b/spec/support/config_upgrader_rubocop.yml
@@ -3,6 +3,46 @@ Style/AccessorMethodName:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+# 1.5 through 1.7
+Layout/SpaceBeforeBrackets: # (new in 1.7)
+  Enabled: true
+Lint/AmbiguousAssignment: # (new in 1.7)
+  Enabled: true
+Lint/UnexpectedBlockArity: # (new in 1.5)
+  Enabled: true
+Style/HashExcept: # (new in 1.7)
+  Enabled: true
+
+  # 1.1 through 1.4
+Lint/DuplicateBranch: # (new in 1.3)
+  Enabled: true
+Lint/DuplicateRegexpCharacterClassElement: # (new in 1.1)
+  Enabled: true
+Lint/EmptyBlock: # (new in 1.1)
+  Enabled: true
+Lint/EmptyClass: # (new in 1.3)
+  Enabled: true
+Lint/NoReturnInBeginEndBlocks: # (new in 1.2)
+  Enabled: true
+Lint/ToEnumArguments: # (new in 1.1)
+  Enabled: true
+Lint/UnmodifiedReduceAccumulator: # (new in 1.1)
+  Enabled: true
+Style/ArgumentsForwarding: # (new in 1.1)
+  Enabled: true
+Style/CollectionCompact: # (new in 1.2)
+  Enabled: true
+Style/DocumentDynamicEvalDefinition: # (new in 1.1)
+  Enabled: true
+Style/NegatedIfElseCondition: # (new in 1.2)
+  Enabled: true
+Style/NilLambda: # (new in 1.3)
+  Enabled: true
+Style/RedundantArgument: # (new in 1.4)
+  Enabled: true
+Style/SwapValues: # (new in 1.1)
+  Enabled: true
+
 # 0.91
 Layout/BeginEndAlignment: # (new in 0.91)
   Enabled: true

--- a/spec/support/currently_undocumented_cops.txt
+++ b/spec/support/currently_undocumented_cops.txt
@@ -1,3 +1,3 @@
 RuboCop::Cop::Lint::Syntax
-RuboCop::Cop::Migration::DepartmentName
 RuboCop::Cop::Style::ConditionalAssignment
+RuboCop::Cop::Migration::DepartmentName


### PR DESCRIPTION
Happy 2021!

The versioning scheme change to 1.x was kinda disruptive! A handful of dependencies were unable to resolve following the update. In two cases, the related PRs have been merged and the new versions released, but `rubocop-migrations` appears to be a dead project—fortunately, removing the gem doesn't appear to be a problem.

Per https://github.com/codeclimate/codeclimate-rubocop/pull/263#issuecomment-746438218, I'll hold off on creating the channel branch until this PR is approved and ready to merge.