### PR TITLE
Add channel/rubocop-1-20-0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "activesupport", require: false
 gem "mry", require: false
 gem "parser"
 gem "pry", require: false
-gem "rubocop", "1.18.3", require: false
+gem "rubocop", "1.20.0", require: false
 gem "rubocop-i18n", require: false
 gem "rubocop-graphql", require: false
 gem "rubocop-minitest", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
     mry (0.78.0.0)
       rubocop (>= 0.41.0)
     parallel (1.20.1)
-    parser (3.0.1.1)
+    parser (3.0.2.0)
       ast (~> 2.4.1)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -41,16 +41,16 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
-    rubocop (1.18.3)
+    rubocop (1.20.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 1.9.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.7.0)
+    rubocop-ast (1.11.0)
       parser (>= 3.0.1.1)
     rubocop-graphql (0.9.0)
       rubocop (>= 0.87, < 2)
@@ -94,7 +94,7 @@ DEPENDENCIES
   pry
   rake
   rspec
-  rubocop (= 1.18.3)
+  rubocop (= 1.20.0)
   rubocop-graphql
   rubocop-i18n
   rubocop-minitest

--- a/config/contents/bundler/gem_filename.md
+++ b/config/contents/bundler/gem_filename.md
@@ -1,0 +1,22 @@
+This cop verifies that a project contains Gemfile or gems.rb file and correct
+associated lock file based on the configuration.
+
+### Example: EnforcedStyle: Gemfile (default)
+    # bad
+    Project contains gems.rb and gems.locked files
+
+    # bad
+    Project contains Gemfile and gems.locked file
+
+    # good
+    Project contains Gemfile and Gemfile.lock
+
+### Example: EnforcedStyle: gems.rb
+    # bad
+    Project contains Gemfile and Gemfile.lock files
+
+    # bad
+    Project contains gems.rb and Gemfile.lock file
+
+    # good
+    Project contains gems.rb and gems.locked files

--- a/config/contents/layout/line_end_string_concatenation_indentation.md
+++ b/config/contents/layout/line_end_string_concatenation_indentation.md
@@ -6,8 +6,7 @@ first part. There are some exceptions, such as implicit return values, where the
 concatenated string parts shall be indented regardless of `EnforcedStyle` configuration.
 
 If `EnforcedStyle: indented` is set, it's the second line that shall be indented one step
-more than the first line. Lines 3 and forward shall be aligned with line 2. Here too there
-are exceptions. Values in a hash literal are always aligned.
+more than the first line. Lines 3 and forward shall be aligned with line 2.
 
 ### Example:
     # bad
@@ -29,25 +28,40 @@ are exceptions. Values in a hash literal are always aligned.
         'z'
     end
 
-    my_hash = {
-      first: 'a message' \
-             'in two parts'
-    }
-
 ### Example: EnforcedStyle: aligned (default)
     # bad
     puts 'x' \
       'y'
 
+    my_hash = {
+      first: 'a message' \
+        'in two parts'
+    }
+
     # good
     puts 'x' \
          'y'
+
+    my_hash = {
+      first: 'a message' \
+             'in two parts'
+    }
 
 ### Example: EnforcedStyle: indented
     # bad
     result = 'x' \
              'y'
 
+    my_hash = {
+      first: 'a message' \
+             'in two parts'
+    }
+
     # good
     result = 'x' \
       'y'
+
+    my_hash = {
+      first: 'a message' \
+        'in two parts'
+    }

--- a/config/contents/layout/multiline_method_argument_line_breaks.md
+++ b/config/contents/layout/multiline_method_argument_line_breaks.md
@@ -1,6 +1,9 @@
 This cop ensures that each argument in a multi-line method call
 starts on a separate line.
 
+NOTE: this cop does not move the first argument, if you want that to
+be on a separate line, see `Layout/FirstMethodArgumentLineBreak`.
+
 ### Example:
 
     # bad

--- a/config/contents/lint/ambiguous_range.md
+++ b/config/contents/lint/ambiguous_range.md
@@ -1,0 +1,52 @@
+This cop checks for ambiguous ranges.
+
+Ranges have quite low precedence, which leads to unexpected behaviour when
+using a range with other operators. This cop avoids that by making ranges
+explicit by requiring parenthesis around complex range boundaries (anything
+that is not a basic literal: numerics, strings, symbols, etc.).
+
+NOTE: The cop auto-corrects by wrapping the entire boundary in parentheses, which
+makes the outcome more explicit but is possible to not be the intention of the
+programmer. For this reason, this cop's auto-correct is marked as unsafe (it
+will not change the behaviour of the code, but will not necessarily match the
+intent of the program).
+
+This cop can be configured with `RequireParenthesesForMethodChains` in order to
+specify whether method chains (including `self.foo`) should be wrapped in parens
+by this cop.
+
+NOTE: Regardless of this configuration, if a method receiver is a basic literal
+value, it will be wrapped in order to prevent the ambiguity of `1..2.to_a`.
+
+### Example:
+    # bad
+    x || 1..2
+    (x || 1..2)
+    1..2.to_a
+
+    # good, unambiguous
+    1..2
+    'a'..'z'
+    :bar..:baz
+    MyClass::MIN..MyClass::MAX
+    @min..@max
+    a..b
+    -a..b
+
+    # good, ambiguity removed
+    x || (1..2)
+    (x || 1)..2
+    (x || 1)..(y || 2)
+    (1..2).to_a
+
+### Example: RequireParenthesesForMethodChains: false (default)
+    # good
+    a.foo..b.bar
+    (a.foo)..(b.bar)
+
+### Example: RequireParenthesesForMethodChains: true
+    # bad
+    a.foo..b.bar
+
+    # good
+    (a.foo)..(b.bar)

--- a/config/contents/lint/debugger.md
+++ b/config/contents/lint/debugger.md
@@ -2,8 +2,8 @@ This cop checks for debug calls (such as `debugger` or `binding.pry`) that shoul
 not be kept for production code.
 
 The cop can be configured using `DebuggerMethods`. By default, a number of gems
-debug entrypoints are configured (`Kernel`, `Byebug`, `Capybara`, `Pry`, `Rails`,
-and `WebConsole`). Additional methods can be added.
+debug entrypoints are configured (`Kernel`, `Byebug`, `Capybara`, `debug.rb`,
+`Pry`, `Rails`, `RubyJard`, and `WebConsole`). Additional methods can be added.
 
 Specific default groups can be disabled if necessary:
 

--- a/config/contents/lint/duplicate_branch.md
+++ b/config/contents/lint/duplicate_branch.md
@@ -1,5 +1,5 @@
 This cop checks that there are no repeated bodies
-within `if/unless`, `case-when` and `rescue` constructs.
+within `if/unless`, `case-when`, `case-in` and `rescue` constructs.
 
 With `IgnoreLiteralBranches: true`, branches are not registered
 as offenses if they return a basic literal value (string, symbol,

--- a/config/contents/naming/inclusive_language.md
+++ b/config/contents/naming/inclusive_language.md
@@ -14,6 +14,8 @@ Flagged terms are configurable for the cop. For each flagged term an optional
 Regex can be specified to identify offenses. Suggestions for replacing a flagged term can
 be configured and will be displayed as part of the offense message.
 An AllowedRegex can be specified for a flagged term to exempt allowed uses of the term.
+`WholeWord: true` can be set on a flagged term to indicate the cop should only match when
+a term matches the whole word (partial matches will not be offenses).
 
 ### Example: FlaggedTerms: { whitelist: { Suggestions: ['allowlist'] } }
     # Suggest replacing identifier whitelist with allowlist
@@ -50,3 +52,12 @@ An AllowedRegex can be specified for a flagged term to exempt allowed uses of th
 
     # good
     # They had a master's degree
+
+### Example: FlaggedTerms: { slave: { WholeWord: true } }
+    # Specify that only terms that are full matches will be flagged.
+
+    # bad
+    Slave
+
+    # good (won't be flagged despite containing `slave`)
+    TeslaVehicle

--- a/config/contents/style/block_delimiters.md
+++ b/config/contents/style/block_delimiters.md
@@ -1,6 +1,11 @@
 Check for uses of braces or do/end around single line or
 multi-line blocks.
 
+Methods that can be either procedural or functional and cannot be
+categorised from their usage alone is ignored.
+`lambda`, `proc`, and `it` are their defaults.
+Additional methods can be added to the `IgnoredMethods`.
+
 ### Example: EnforcedStyle: line_count_based (default)
     # bad - single line block
     items.each do |item| item / 5 end
@@ -125,4 +130,15 @@ multi-line blocks.
     }
     def bar(foo)
       puts foo
+    end
+
+### Example: IgnoredMethods: ['lambda', 'proc', 'it' ] (default)
+
+    # good
+    foo = lambda do |x|
+      puts "Hello, #{x}"
+    end
+
+    foo = lambda do |x|
+      x * 100
     end

--- a/config/contents/style/comment_annotation.md
+++ b/config/contents/style/comment_annotation.md
@@ -1,6 +1,9 @@
 This cop checks that comment annotation keywords are written according
 to guidelines.
 
+Annotation keywords can be specified by overriding the cop's `Keywords`
+configuration. Keywords are allowed to be single words or phrases.
+
 NOTE: With a multiline comment block (where each line is only a
 comment), only the first line will be able to register an offense, even
 if an annotation keyword starts another line. This is done to prevent

--- a/config/contents/style/commented_keyword.md
+++ b/config/contents/style/commented_keyword.md
@@ -7,6 +7,7 @@ are allowed.
 
 Auto-correction removes comments from `end` keyword and keeps comments
 for `class`, `module`, `def` and `begin` above the keyword.
+It is marked as unsafe auto-correction as it may remove meaningful comments.
 
 ### Example:
     # bad

--- a/config/contents/style/eval_with_location.md
+++ b/config/contents/style/eval_with_location.md
@@ -38,7 +38,7 @@ line values.
     RUBY
 
 This cop works only when a string literal is given as a code string.
-No offence is reported if a string variable is given as below:
+No offense is reported if a string variable is given as below:
 
 ### Example:
     # not checked

--- a/config/contents/style/identical_conditional_branches.md
+++ b/config/contents/style/identical_conditional_branches.md
@@ -2,6 +2,22 @@ This cop checks for identical expressions at the beginning or end of
 each branch of a conditional expression. Such expressions should normally
 be placed outside the conditional expression - before or after it.
 
+This cop is marked unsafe auto-correction as the order of method invocations
+must be guaranteed in the following case:
+
+[source,ruby]
+----
+if method_that_modifies_global_state # 1
+    method_that_relies_on_global_state # 2
+    foo                                # 3
+else
+    method_that_relies_on_global_state # 2
+    bar                                # 3
+end
+----
+
+In such a case, auto-correction may change the invocation order.
+
 NOTE: The cop is poorly named and some people might think that it actually
 checks for duplicated conditional branches. The name will probably be changed
 in a future major RuboCop release.

--- a/config/contents/style/missing_else.md
+++ b/config/contents/style/missing_else.md
@@ -1,5 +1,8 @@
 Checks for `if` expressions that do not have an `else` branch.
 
+NOTE: Pattern matching is allowed to have no `else` branch because unlike `if` and `case`,
+it raises `NoMatchingPatternError` if the pattern doesn't match and without having `else`.
+
 Supported styles are: if, case, both.
 
 ### Example: EnforcedStyle: if

--- a/config/contents/style/mutable_constant.md
+++ b/config/contents/style/mutable_constant.md
@@ -9,7 +9,15 @@ frozen objects so there is a decent chance of getting some false
 positives. Luckily, there is no harm in freezing an already
 frozen object.
 
+From Ruby 3.0, this cop honours the magic comment
+'shareable_constant_value'. When this magic comment is set to any
+acceptable value other than none, it will suppress the offenses
+raised by this cop. It enforces frozen state.
+
 NOTE: Regexp and Range literals are frozen objects since Ruby 3.0.
+
+NOTE: From Ruby 3.0, this cop allows explicit freezing of interpolated
+string literals when `# frozen-string-literal: true` is used.
 
 ### Example: EnforcedStyle: literals (default)
     # bad
@@ -47,3 +55,17 @@ NOTE: Regexp and Range literals are frozen objects since Ruby 3.0.
         puts 1
       end
     end.freeze
+
+### Example:
+    # Magic comment - shareable_constant_value: literal
+
+    # bad
+    CONST = [1, 2, 3]
+
+    # good
+    # shareable_constant_value: literal
+    CONST = [1, 2, 3]
+
+NOTE: This special directive helps to create constants
+that hold only immutable objects, or Ractor-shareable
+constants. - ruby docs

--- a/config/contents/style/redundant_freeze.md
+++ b/config/contents/style/redundant_freeze.md
@@ -2,6 +2,9 @@ This cop check for uses of `Object#freeze` on immutable objects.
 
 NOTE: Regexp and Range literals are frozen objects since Ruby 3.0.
 
+NOTE: From Ruby 3.0, this cop allows explicit freezing of interpolated
+string literals when `# frozen-string-literal: true` is used.
+
 ### Example:
     # bad
     CONST = 1.freeze

--- a/config/contents/style/redundant_self_assignment_branch.md
+++ b/config/contents/style/redundant_self_assignment_branch.md
@@ -1,0 +1,18 @@
+This cop checks for places where conditional branch makes redundant self-assignment.
+
+It only detects local variable because it may replace state of instance variable,
+class variable, and global variable that have state across methods with `nil`.
+
+### Example:
+
+    # bad
+    foo = condition ? bar : foo
+
+    # good
+    foo = bar if condition
+
+    # bad
+    foo = condition ? foo : bar
+
+    # good
+    foo = bar unless condition

--- a/config/contents/style/special_global_vars.md
+++ b/config/contents/style/special_global_vars.md
@@ -1,8 +1,13 @@
 
 This cop looks for uses of Perl-style global variables.
+Correcting to global variables in the 'English' library
+will add a require statement to the top of the file if
+enabled by RequireEnglish config.
 
 ### Example: EnforcedStyle: use_english_names (default)
     # good
+    require 'English' # or this could be in another file.
+
     puts $LOAD_PATH
     puts $LOADED_FEATURES
     puts $PROGRAM_NAME

--- a/config/contents/style/struct_inheritance.md
+++ b/config/contents/style/struct_inheritance.md
@@ -1,5 +1,8 @@
 This cop checks for inheritance from Struct.new.
 
+It is marked as unsafe auto-correction because it will change the
+inheritance tree (e.g. return value of `Module#ancestors`).
+
 ### Example:
     # bad
     class Person < Struct.new(:first_name, :last_name)

--- a/config/contents/style/word_array.md
+++ b/config/contents/style/word_array.md
@@ -4,6 +4,9 @@ strings, that are not using the %w() syntax.
 Alternatively, it can check for uses of the %w() syntax, in projects
 which do not want to include that syntax.
 
+NOTE: When using the `percent` style, %w() arrays containing a space
+will be registered as offenses.
+
 Configuration option: MinSize
 If set, arrays with fewer elements than this value will not trigger the
 cop. For example, a `MinSize` of `3` will not enforce a style on an
@@ -16,9 +19,15 @@ array of 2 or fewer elements.
     # bad
     ['foo', 'bar', 'baz']
 
+    # bad (contains spaces)
+    %w[foo\ bar baz\ quux]
+
 ### Example: EnforcedStyle: brackets
     # good
     ['foo', 'bar', 'baz']
 
     # bad
     %w[foo bar baz]
+
+    # good (contains spaces)
+    ['foo bar', 'baz quux']

--- a/spec/rubocop/config_patch_spec.rb
+++ b/spec/rubocop/config_patch_spec.rb
@@ -32,7 +32,7 @@ module CC::Engine
       expected = <<~EOM
         The `Layout/AlignArguments` cop has been renamed to `Layout/ArgumentAlignment`.
         (obsolete configuration found in .rubocop.yml, please update it)
-        unrecognized cop Layout/AlignArguments found in .rubocop.yml
+        unrecognized cop or department Layout/AlignArguments found in .rubocop.yml
         Did you mean `Layout/HashAlignment`?
       EOM
 
@@ -53,7 +53,7 @@ module CC::Engine
       expected = <<~EOM
         The `Style/TrailingComma` cop has been removed. Please use `Style/TrailingCommaInArguments`, `Style/TrailingCommaInArrayLiteral` and/or `Style/TrailingCommaInHashLiteral` instead.
         (obsolete configuration found in .rubocop.yml, please update it)
-        unrecognized cop Style/TrailingComma found in .rubocop.yml
+        unrecognized cop or department Style/TrailingComma found in .rubocop.yml
         Did you mean `Style/TrailingCommaInArguments`?
       EOM
 

--- a/spec/support/config_upgrader_rubocop.yml
+++ b/spec/support/config_upgrader_rubocop.yml
@@ -3,6 +3,12 @@ Style/AccessorMethodName:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+# 1.19
+Lint/AmbiguousRange:
+  Enabled: true
+Style/RedundantSelfAssignmentBranch:
+  Enabled: true
+
 # 1.18
 Layout/LineEndStringConcatenationIndentation: # (new in 1.18)
   Enabled: true


### PR DESCRIPTION
Updates rubocop to [`v1.20.0`](https://github.com/rubocop/rubocop/releases/tag/v1.20.0). 

Currently targeting channel/rubocop-1-18-3 because channel/rubocop-1-20-0 does not exist yet. 