### PR TITLE
Add channel/rubocop-1-21-0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "activesupport", require: false
 gem "mry", require: false
 gem "parser"
 gem "pry", require: false
-gem "rubocop", "1.20.0", require: false
+gem "rubocop", "1.21.0", require: false
 gem "rubocop-i18n", require: false
 gem "rubocop-graphql", require: false
 gem "rubocop-minitest", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     minitest (5.14.4)
     mry (0.78.0.0)
       rubocop (>= 0.41.0)
-    parallel (1.20.1)
+    parallel (1.21.0)
     parser (3.0.2.0)
       ast (~> 2.4.1)
     pry (0.14.1)
@@ -41,7 +41,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
-    rubocop (1.20.0)
+    rubocop (1.21.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -81,7 +81,7 @@ GEM
     test-prof (1.0.6)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.0.0)
+    unicode-display_width (2.1.0)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -94,7 +94,7 @@ DEPENDENCIES
   pry
   rake
   rspec
-  rubocop (= 1.20.0)
+  rubocop (= 1.21.0)
   rubocop-graphql
   rubocop-i18n
   rubocop-minitest

--- a/config/contents/bundler/insecure_protocol_source.md
+++ b/config/contents/bundler/insecure_protocol_source.md
@@ -1,15 +1,15 @@
-The symbol argument `:gemcutter`, `:rubygems`, and `:rubyforge`
-are deprecated. So please change your source to URL string that
-'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
+Passing symbol arguments to `source` (e.g. `source :rubygems`) is
+deprecated because they default to using HTTP requests. Instead, specify
+`'https://rubygems.org'` if possible, or `'http://rubygems.org'` if not.
 
-This autocorrect will replace these symbols with 'https://rubygems.org'.
-Because it is secure, HTTPS request is strongly recommended. And in
-most use cases HTTPS will be fine.
+When autocorrecting, this cop will replace symbol arguments with
+`'https://rubygems.org'`.
 
-However, it don't replace all `sources` of `http://` with `https://`.
-For example, when specifying an internal gem server using HTTP on the
-intranet, a use case where HTTPS cannot be specified was considered.
-Consider using HTTP only if you cannot use HTTPS.
+This cop will not replace existing sources that use `http://`. This may
+be necessary where HTTPS is not available. For example, where using an
+internal gem server via an intranet, or where HTTPS is prohibited.
+However, you should strongly prefer `https://` where possible, as it is
+more secure.
 
 ### Example:
     # bad
@@ -19,4 +19,4 @@ Consider using HTTP only if you cannot use HTTPS.
 
     # good
     source 'https://rubygems.org' # strongly recommended
-    source 'http://rubygems.org'
+    source 'http://rubygems.org' # use only if HTTPS is unavailable

--- a/config/contents/lint/ambiguous_operator_precedence.md
+++ b/config/contents/lint/ambiguous_operator_precedence.md
@@ -1,0 +1,24 @@
+This cop looks for expressions containing multiple binary operators
+where precedence is ambiguous due to lack of parentheses. For example,
+in `1 + 2 * 3`, the multiplication will happen before the addition, but
+lexically it appears that the addition will happen first.
+
+The cop does not consider unary operators (ie. `!a` or `-b`) or comparison
+operators (ie. `a =~ b`) because those are not ambiguous.
+
+NOTE: Ranges are handled by `Lint/AmbiguousRange`.
+
+### Example:
+    # bad
+    a + b * c
+    a || b && c
+    a ** b + c
+
+    # good (different precedence)
+    a + (b * c)
+    a || (b && c)
+    (a ** b) + c
+
+    # good (same precedence)
+    a + b + c
+    a * b / c % d

--- a/config/contents/lint/incompatible_io_select_with_fiber_scheduler.md
+++ b/config/contents/lint/incompatible_io_select_with_fiber_scheduler.md
@@ -1,0 +1,16 @@
+
+This cop checks for `IO.select` that is incompatible with Fiber Scheduler since Ruby 3.0.
+
+### Example:
+
+    # bad
+    IO.select([io], [], [], timeout)
+
+    # good
+    io.wait_readable(timeout)
+
+    # bad
+    IO.select([], [io], [], timeout)
+
+    # good
+    io.wait_writable(timeout)

--- a/config/contents/style/and_or.md
+++ b/config/contents/style/and_or.md
@@ -2,6 +2,10 @@ This cop checks for uses of `and` and `or`, and suggests using `&&` and
 `||` instead. It can be configured to check only in conditions or in
 all contexts.
 
+It is marked as unsafe auto-correction because it may change the
+operator precedence between logical operators (`&&` and `||`) and
+semantic operators (`and` and `or`).
+
 ### Example: EnforcedStyle: always
     # bad
     foo.save and return

--- a/config/contents/style/case_equality.md
+++ b/config/contents/style/case_equality.md
@@ -1,8 +1,10 @@
 This cop checks for uses of the case equality operator(===).
 
+If `AllowOnConstant` option is enabled, the cop will ignore violations when the receiver of
+the case equality operator is a constant.
+
 ### Example:
     # bad
-    Array === something
     (1..100) === 7
     /something/ === some_string
 
@@ -11,15 +13,10 @@ This cop checks for uses of the case equality operator(===).
     (1..100).include?(7)
     /something/.match?(some_string)
 
-### Example: AllowOnConstant
-    # Style/CaseEquality:
-    #   AllowOnConstant: true
-
+### Example: AllowOnConstant: false (default)
     # bad
-    (1..100) === 7
-    /something/ === some_string
+    Array === something
 
+### Example: AllowOnConstant: true
     # good
     Array === something
-    (1..100).include?(7)
-    /something/.match?(some_string)

--- a/spec/support/config_upgrader_rubocop.yml
+++ b/spec/support/config_upgrader_rubocop.yml
@@ -3,6 +3,12 @@ Style/AccessorMethodName:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+# 1.21
+Lint/AmbiguousOperatorPrecedence:
+  Enabled: true
+Lint/IncompatibleIoSelectWithFiberScheduler:
+  Enabled: true
+
 # 1.19
 Lint/AmbiguousRange:
   Enabled: true


### PR DESCRIPTION
Updates rubocop to [`1.21.0`](https://github.com/rubocop/rubocop/releases/tag/v1.21.0).