### PR TITLE
Add support for rubocop-shopify

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "rubocop-rails", require: false
 gem "rubocop-rake", require: false
 gem "rubocop-rspec", require: false
 gem "rubocop-sequel", require: false
+gem "rubocop-shopify", require: false
 gem "rubocop-sorbet", require: false
 gem "rubocop-thread_safety", require: false
 gem "safe_yaml"


### PR DESCRIPTION
This PR adds support for the rubocop-shopify gem, enabling the Shopify ruby style guide configuration.

To enable, add this configuration to the top of your `rubocop.yml` file:

```yaml
inherit_gem:
  rubocop-shopify: rubocop.yml
```