### PR TITLE
Update rubocop to 1.24.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "activesupport", require: false
 gem "mry", require: false
 gem "parser"
 gem "pry", require: false
-gem "rubocop", "1.23.0", require: false
+gem "rubocop", "1.24.1", require: false
 gem "rubocop-i18n", require: false
 gem "rubocop-graphql", require: false
 gem "rubocop-minitest", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,23 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.4.1)
+    activesupport (7.0.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     ast (2.4.2)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
-    diff-lcs (1.4.4)
+    diff-lcs (1.5.0)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
-    minitest (5.14.4)
+    minitest (5.15.0)
     mry (0.78.0.0)
       rubocop (>= 0.41.0)
     parallel (1.21.0)
-    parser (3.0.3.1)
+    parser (3.1.0.0)
       ast (~> 2.4.1)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -41,37 +40,39 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.3)
-    rubocop (1.23.0)
+    rubocop (1.24.1)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 1.12.0, < 2.0)
+      rubocop-ast (>= 1.15.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.14.0)
+    rubocop-ast (1.15.1)
       parser (>= 3.0.1.1)
-    rubocop-graphql (0.11.2)
+    rubocop-graphql (0.12.0)
       rubocop (>= 0.87, < 2)
     rubocop-i18n (3.0.0)
       rubocop (~> 1.0)
     rubocop-minitest (0.17.0)
       rubocop (>= 0.90, < 2.0)
-    rubocop-performance (1.12.0)
+    rubocop-performance (1.13.1)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    rubocop-rails (2.12.4)
+    rubocop-rails (2.13.0)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
-    rubocop-rspec (2.6.0)
+    rubocop-rspec (2.7.0)
       rubocop (~> 1.19)
     rubocop-sequel (0.3.3)
       rubocop (~> 1.0)
-    rubocop-sorbet (0.6.3)
+    rubocop-shopify (2.3.0)
+      rubocop (~> 1.22)
+    rubocop-sorbet (0.6.5)
       rubocop (>= 0.90.0)
     rubocop-thread_safety (0.4.4)
       rubocop (>= 0.53.0)
@@ -81,7 +82,6 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
-    zeitwerk (2.5.1)
 
 PLATFORMS
   ruby
@@ -93,7 +93,7 @@ DEPENDENCIES
   pry
   rake
   rspec
-  rubocop (= 1.23.0)
+  rubocop (= 1.24.1)
   rubocop-graphql
   rubocop-i18n
   rubocop-minitest
@@ -102,6 +102,7 @@ DEPENDENCIES
   rubocop-rake
   rubocop-rspec
   rubocop-sequel
+  rubocop-shopify
   rubocop-sorbet
   rubocop-thread_safety
   safe_yaml

--- a/config/contents/gemspec/require_mfa.md
+++ b/config/contents/gemspec/require_mfa.md
@@ -1,18 +1,18 @@
 Requires a gemspec to have `rubygems_mfa_required` metadata set.
 
 This setting tells RubyGems that MFA is required for accounts to
-be able perform any of these privileged operations:
+be able perform privileged operations, such as (see
+RubyGems' documentation for the full list of privileged operations):
 
-* gem push
-* gem yank
-* gem owner --add/remove
+* `gem push`
+* `gem yank`
+* `gem owner --add/remove`
 * adding or removing owners using gem ownership page
 
 This helps make your gem more secure, as users can be more
 confident that gem updates were pushed by maintainers.
 
 ### Example:
-
     # bad
     Gem::Specification.new do |spec|
       # no `rubygems_mfa_required` metadata specified

--- a/config/contents/layout/comment_indentation.md
+++ b/config/contents/layout/comment_indentation.md
@@ -26,3 +26,17 @@ This cop checks the indentation of comments.
     if true
       true
     end
+
+### Example: AllowForAlignment: false (default)
+    # bad
+    a = 1 # A really long comment
+          # spanning two lines.
+
+    # good
+    # A really long comment spanning one line.
+    a = 1
+
+### Example: AllowForAlignment: true
+    # good
+    a = 1 # A really long comment
+          # spanning two lines.

--- a/config/contents/lint/deprecated_class_methods.md
+++ b/config/contents/lint/deprecated_class_methods.md
@@ -7,6 +7,7 @@ This cop checks for uses of the deprecated class method usages.
     File.exists?(some_path)
     Dir.exists?(some_path)
     iterator?
+    ENV.freeze # Calling `Env.freeze` raises `TypeError` since Ruby 2.7.
     Socket.gethostbyname(host)
     Socket.gethostbyaddr(host)
 
@@ -17,5 +18,6 @@ This cop checks for uses of the deprecated class method usages.
     File.exist?(some_path)
     Dir.exist?(some_path)
     block_given?
+    ENV # `ENV.freeze` cannot prohibit changes to environment variables.
     Addrinfo.getaddrinfo(nodename, service)
     Addrinfo.tcp(host, port).getnameinfo

--- a/config/contents/lint/incompatible_io_select_with_fiber_scheduler.md
+++ b/config/contents/lint/incompatible_io_select_with_fiber_scheduler.md
@@ -14,3 +14,8 @@ This cop checks for `IO.select` that is incompatible with Fiber Scheduler since 
 
     # good
     io.wait_writable(timeout)
+
+### Safety:
+
+This cop's autocorrection is unsafe because `NoMethodError` occurs
+if `require 'io/wait'` is not called.

--- a/config/contents/naming/block_forwarding.md
+++ b/config/contents/naming/block_forwarding.md
@@ -1,0 +1,30 @@
+In Ruby 3.1, anonymous block forwarding has been added.
+
+This cop identifies places where `do_something(&block)` can be replaced
+by `do_something(&)`.
+
+It also supports the opposite style by alternative `explicit` option.
+
+### Example: EnforcedStyle: anonymous (default)
+
+    # bad
+    def foo(&block)
+      bar(&block)
+    end
+
+    # good
+    def foo(&)
+      bar(&)
+    end
+
+### Example: EnforcedStyle: explicit
+
+    # bad
+    def foo(&)
+      bar(&)
+    end
+
+    # good
+    def foo(&block)
+      bar(&block)
+    end

--- a/config/contents/security/open.md
+++ b/config/contents/security/open.md
@@ -1,10 +1,14 @@
-This cop checks for the use of `Kernel#open` and `URI.open`.
+This cop checks for the use of `Kernel#open` and `URI.open` with dynamic
+data.
 
 `Kernel#open` and `URI.open` enable not only file access but also process
 invocation by prefixing a pipe symbol (e.g., `open("| ls")`).
 So, it may lead to a serious security risk by using variable input to
 the argument of `Kernel#open` and `URI.open`. It would be better to use
 `File.open`, `IO.popen` or `URI.parse#open` explicitly.
+
+NOTE: `open` and `URI.open` with literal strings are not flagged by this
+cop.
 
 ### Safety:
 
@@ -14,9 +18,15 @@ in a class and then used without a receiver in that class.
 ### Example:
     # bad
     open(something)
+    open("| #{something}")
     URI.open(something)
 
     # good
     File.open(something)
     IO.popen(something)
     URI.parse(something).open
+
+    # good (literal strings)
+    open("foo.text")
+    open("| foo")
+    URI.open("http://example.com")

--- a/config/contents/style/character_literal.md
+++ b/config/contents/style/character_literal.md
@@ -1,4 +1,10 @@
 Checks for uses of the character literal ?x.
+Starting with Ruby 1.9 character literals are
+essentially one-character strings, so this syntax
+is mostly redundant at this point.
+
+? character literal can be used to express meta and control character.
+That's a good use case of ? literal so it doesn't count it as an offense.
 
 ### Example:
     # bad
@@ -7,5 +13,6 @@ Checks for uses of the character literal ?x.
     # good
     'x'
 
-    # good
+    # good - control & meta escapes
     ?\C-\M-d
+    "\C-\M-d" # same as above

--- a/config/contents/style/collection_compact.md
+++ b/config/contents/style/collection_compact.md
@@ -12,6 +12,7 @@ when the receiver is a hash object.
 
 ### Example:
     # bad
+    array.reject(&:nil?)
     array.reject { |e| e.nil? }
     array.select { |e| !e.nil? }
 
@@ -19,6 +20,7 @@ when the receiver is a hash object.
     array.compact
 
     # bad
+    hash.reject!(&:nil?)
     hash.reject! { |k, v| v.nil? }
     hash.select! { |k, v| !v.nil? }
 

--- a/config/contents/style/file_read.md
+++ b/config/contents/style/file_read.md
@@ -1,0 +1,31 @@
+Favor `File.(bin)read` convenience methods.
+
+### Example:
+    ## text mode
+    # bad
+    File.open(filename).read
+    File.open(filename, &:read)
+    File.open(filename) { |f| f.read }
+    File.open(filename) do |f|
+      f.read
+    end
+    File.open(filename, 'r').read
+    File.open(filename, 'r', &:read)
+    File.open(filename, 'r') do |f|
+      f.read
+    end
+
+    # good
+    File.read(filename)
+
+### Example:
+    ## binary mode
+    # bad
+    File.open(filename, 'rb').read
+    File.open(filename, 'rb', &:read)
+    File.open(filename, 'rb') do |f|
+      f.read
+    end
+
+    # good
+    File.binread(filename)

--- a/config/contents/style/file_write.md
+++ b/config/contents/style/file_write.md
@@ -1,0 +1,23 @@
+Favor `File.(bin)write` convenience methods.
+
+### Example:
+    ## text mode
+    # bad
+    File.open(filename, 'w').write(content)
+    File.open(filename, 'w') do |f|
+      f.write(content)
+    end
+
+    # good
+    File.write(filename, content)
+
+### Example:
+    ## binary mode
+    # bad
+    File.open(filename, 'wb').write(content)
+    File.open(filename, 'wb') do |f|
+      f.write(content)
+    end
+
+    # good
+    File.binwrite(filename, content)

--- a/config/contents/style/hash_syntax.md
+++ b/config/contents/style/hash_syntax.md
@@ -14,6 +14,10 @@ all symbols for keys
 * ruby19_no_mixed_keys - forces use of ruby 1.9 syntax and forbids mixed
 syntax hashes
 
+This cop has `EnforcedShorthandSyntax` option.
+It can enforce either the use of the explicit hash value syntax or
+the use of Ruby 3.1's hash value shorthand syntax.
+
 ### Example: EnforcedStyle: ruby19 (default)
     # bad
     {:a => 2}
@@ -49,3 +53,19 @@ syntax hashes
     # good
     {a: 1, b: 2}
     {:c => 3, 'd' => 4}
+
+### Example: EnforcedShorthandSyntax: always (default)
+
+    # bad
+    {foo: foo, bar: bar}
+
+    # good
+    {foo:, bar:}
+
+### Example: EnforcedShorthandSyntax: never
+
+    # bad
+    {foo:, bar:}
+
+    # good
+    {foo: foo, bar: bar}

--- a/config/contents/style/map_to_hash.md
+++ b/config/contents/style/map_to_hash.md
@@ -1,0 +1,24 @@
+This cop looks for uses of `map.to_h` or `collect.to_h` that could be
+written with just `to_h` in Ruby >= 2.6.
+
+NOTE: `Style/HashTransformKeys` and `Style/HashTransformValues` will
+also change this pattern if only hash keys or hash values are being
+transformed.
+
+### Safety:
+
+This cop is unsafe, as it can produce false positives if the receiver
+is not an `Enumerable`.
+
+### Example:
+    # bad
+    something.map { |v| [v, v * 2] }.to_h
+
+    # good
+    something.to_h { |v| [v, v * 2] }
+
+    # bad
+    {foo: bar}.collect { |k, v| [k.to_s, v.do_something] }.to_h
+
+    # good
+    {foo: bar}.to_h { |k, v| [k.to_s, v.do_something] }

--- a/config/contents/style/method_call_with_args_parentheses.md
+++ b/config/contents/style/method_call_with_args_parentheses.md
@@ -38,9 +38,11 @@ options.
 NOTE: Parentheses are still allowed in cases where omitting them
 results in ambiguous or syntactically incorrect code. For example,
 parentheses are required around a method with arguments when inside an
-endless method definition introduced in Ruby 3.0.  Parentheses are also
+endless method definition introduced in Ruby 3.0. Parentheses are also
 allowed when forwarding arguments with the triple-dot syntax introduced
 in Ruby 2.7 as omitting them starts an endless range.
+And Ruby 3.1's hash omission syntax has a case that requires parentheses
+because the issue https://bugs.ruby-lang.org/issues/18396.
 
 ### Example: EnforcedStyle: require_parentheses (default)
 

--- a/config/contents/style/method_def_parentheses.md
+++ b/config/contents/style/method_def_parentheses.md
@@ -1,8 +1,13 @@
 This cop checks for parentheses around the arguments in method
 definitions. Both instance and class/singleton methods are checked.
 
-This cop does not consider endless methods, since parentheses are
-always required for them.
+Regardless of style, parentheses are necessary for:
+
+1. Endless methods
+2. Argument lists containing a `forward-arg` (`...`)
+3. Argument lists containing an anonymous block forwarding (`&`)
+
+Removing the parens would be a syntax error here.
 
 ### Example: EnforcedStyle: require_parentheses (default)
     # The `require_parentheses` style requires method definitions

--- a/config/contents/style/numeric_literals.md
+++ b/config/contents/style/numeric_literals.md
@@ -21,3 +21,8 @@ of digits in them.
 
     # bad
     10_000_00 # typical representation of $10,000 in cents
+
+### Example: AllowedNumbers: [3000]
+
+    # good
+    3000 # You can specify allowed numbers. (e.g. port number)

--- a/lib/cc/engine/content_resolver.rb
+++ b/lib/cc/engine/content_resolver.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support"
 require "active_support/core_ext/string"
 
 module CC

--- a/spec/support/config_upgrader_rubocop.yml
+++ b/spec/support/config_upgrader_rubocop.yml
@@ -3,6 +3,16 @@ Style/AccessorMethodName:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+# 1.24
+Naming/BlockForwarding:
+  Enabled: true
+Style/FileRead:
+  Enabled: true
+Style/FileWrite:
+  Enabled: true
+Style/MapToHash:
+  Enabled: true
+
 # 1.23
 Gemspec/RequireMFA:
   Enabled: true


### PR DESCRIPTION
- General bundle update for Ruby 3.1 compatibility.
- Update the docs too.
- Fix a constant resolution issue with active_support 7.