### PR TITLE
QUA-619: Remove safe_yaml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem "rubocop-rspec", require: false
 gem "rubocop-sequel", require: false
 gem "rubocop-sorbet", require: false
 gem "rubocop-thread_safety", require: false
-gem "safe_yaml"
 gem "test-prof", require: false
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,6 @@ GEM
     rubocop-thread_safety (0.4.4)
       rubocop (>= 0.53.0)
     ruby-progressbar (1.11.0)
-    safe_yaml (1.0.5)
     test-prof (1.0.7)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -104,7 +103,6 @@ DEPENDENCIES
   rubocop-sequel
   rubocop-sorbet
   rubocop-thread_safety
-  safe_yaml
   test-prof
 
 BUNDLED WITH

--- a/lib/cc/engine/issue.rb
+++ b/lib/cc/engine/issue.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-require "safe_yaml"
 require "cc/engine/content_resolver"
-
-SafeYAML::OPTIONS[:default_mode] = :safe
 
 module CC
   module Engine
@@ -71,7 +68,12 @@ module CC
       end
 
       def cop_list
-        @cop_list ||= YAML.load_file(expand_config_path("cops.yml"))
+        @cop_list ||= yaml_safe_load(expand_config_path("cops.yml"))
+      end
+
+      def yaml_safe_load(path)
+        yaml_code = ERB.new(File.read(path)).result
+        YAML.safe_load(yaml_code)
       end
 
       def expand_config_path(path)

--- a/lib/cc/engine/issue.rb
+++ b/lib/cc/engine/issue.rb
@@ -72,8 +72,7 @@ module CC
       end
 
       def yaml_safe_load(path)
-        yaml_code = ERB.new(File.read(path)).result
-        YAML.safe_load(yaml_code)
+        YAML.safe_load(File.read(path))
       end
 
       def expand_config_path(path)


### PR DESCRIPTION
This PR removes the `safe_yaml` gem and uses `YAML.safe_load` instead to load up the `cops.yml` config file.

This fixes the `Style/WordArray` cop not raising issues when running analyses.

https://codeclimate.atlassian.net/browse/QUA-619