### PR TITLE
QUA-619: remove safe_yaml gem (rubocop-1-23-0)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ gem "rubocop-sequel", require: false
 gem "rubocop-shopify", require: false
 gem "rubocop-sorbet", require: false
 gem "rubocop-thread_safety", require: false
-gem "safe_yaml"
 gem "test-prof", require: false
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,12 +71,13 @@ GEM
       rubocop (~> 1.19)
     rubocop-sequel (0.3.3)
       rubocop (~> 1.0)
+    rubocop-shopify (2.3.0)
+      rubocop (~> 1.22)
     rubocop-sorbet (0.6.3)
       rubocop (>= 0.90.0)
     rubocop-thread_safety (0.4.4)
       rubocop (>= 0.53.0)
     ruby-progressbar (1.11.0)
-    safe_yaml (1.0.5)
     test-prof (1.0.7)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -102,9 +103,9 @@ DEPENDENCIES
   rubocop-rake
   rubocop-rspec
   rubocop-sequel
+  rubocop-shopify
   rubocop-sorbet
   rubocop-thread_safety
-  safe_yaml
   test-prof
 
 BUNDLED WITH

--- a/lib/cc/engine/issue.rb
+++ b/lib/cc/engine/issue.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-require "safe_yaml"
 require "cc/engine/content_resolver"
-
-SafeYAML::OPTIONS[:default_mode] = :safe
 
 module CC
   module Engine
@@ -71,7 +68,11 @@ module CC
       end
 
       def cop_list
-        @cop_list ||= YAML.load_file(expand_config_path("cops.yml"))
+        @cop_list ||= yaml_safe_load(expand_config_path("cops.yml"))
+      end
+
+      def yaml_safe_load(path)
+        YAML.safe_load(File.read(path))
       end
 
       def expand_config_path(path)


### PR DESCRIPTION
Remove safe_yaml gem from channel/rubocop-1-23-0