### PR TITLE
QUA-619: remove safe_yaml gem (rubocop-1-30-0)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ gem "rubocop-sequel", require: false
 gem "rubocop-shopify", require: false
 gem "rubocop-sorbet", require: false
 gem "rubocop-thread_safety", require: false
-gem "safe_yaml"
 gem "test-prof", require: false
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,6 @@ GEM
     rubocop-thread_safety (0.4.4)
       rubocop (>= 0.53.0)
     ruby-progressbar (1.11.0)
-    safe_yaml (1.0.5)
     test-prof (1.0.9)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -105,7 +104,6 @@ DEPENDENCIES
   rubocop-shopify
   rubocop-sorbet
   rubocop-thread_safety
-  safe_yaml
   test-prof
 
 BUNDLED WITH

--- a/lib/cc/engine/issue.rb
+++ b/lib/cc/engine/issue.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-require "safe_yaml"
 require "cc/engine/content_resolver"
-
-SafeYAML::OPTIONS[:default_mode] = :safe
 
 module CC
   module Engine
@@ -71,7 +68,11 @@ module CC
       end
 
       def cop_list
-        @cop_list ||= YAML.load_file(expand_config_path("cops.yml"))
+        @cop_list ||= yaml_safe_load(expand_config_path("cops.yml"))
+      end
+
+      def yaml_safe_load(path)
+        YAML.safe_load(File.read(path))
       end
 
       def expand_config_path(path)


### PR DESCRIPTION
Remove the safe_yaml gem for channel/rubocop-1-30-0