### PR TITLE
allow standard to be run with rubocop. Fixes #351

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "rubocop-sequel", require: false
 gem "rubocop-shopify", require: false
 gem "rubocop-sorbet", require: false
 gem "rubocop-thread_safety", require: false
+gem "standard", require: false
 gem "test-prof", require: false
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,9 @@ GEM
     rubocop-thread_safety (0.4.4)
       rubocop (>= 0.53.0)
     ruby-progressbar (1.11.0)
+    standard (1.18.0)
+      rubocop (= 1.39.0)
+      rubocop-performance (= 1.15.0)
     test-prof (1.0.11)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
@@ -103,6 +106,7 @@ DEPENDENCIES
   rubocop-shopify
   rubocop-sorbet
   rubocop-thread_safety
+  standard
   test-prof
 
 BUNDLED WITH


### PR DESCRIPTION
Includes the standard gem for those who want to use it in rubocop (see here: https://github.com/testdouble/standard#usage-via-rubocop)

Addresses #351 