### PR TITLE
Add rubocop-rspec_rails to channel/rubocop-1-56-3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "rubocop-performance", require: false
 gem "rubocop-rails", require: false
 gem "rubocop-rake", require: false
 gem "rubocop-rspec", require: false
+gem "rubocop-rspec_rails", require: false
 gem "rubocop-sequel", require: false
 gem "rubocop-shopify", require: false
 gem "rubocop-sorbet", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
       rubocop-factory_bot (~> 2.22)
+    rubocop-rspec_rails (2.28.2)
+      rubocop (~> 1.40)
     rubocop-sequel (0.3.4)
       rubocop (~> 1.0)
     rubocop-shopify (2.14.0)
@@ -111,6 +113,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rake
   rubocop-rspec
+  rubocop-rspec_rails
   rubocop-sequel
   rubocop-shopify
   rubocop-sorbet


### PR DESCRIPTION
Rubocop-rspec has extracted the rails cops to rubocop-rspec_rails
> the cops related to rspec-rails are aliased (RSpec/Rails/Foo == RSpecRails/Foo) until v3.0 is released

https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md#2280-2024-03-30

So it would be nice to support it before v3 is released