### PR TITLE
Add rubocop-obsession support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "rubocop-factory_bot", require: false
 gem "rubocop-graphql", require: false
 gem "rubocop-i18n", require: false
 gem "rubocop-minitest", require: false
+gem "rubocop-obsession", require: false
 gem "rubocop-performance", require: false
 gem "rubocop-rails", require: false
 gem "rubocop-rails-omakase", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,9 @@ GEM
     rubocop-minitest (0.35.0)
       rubocop (>= 1.61, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-obsession (0.1.5)
+      activesupport
+      rubocop (~> 1.41)
     rubocop-performance (1.21.1)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
@@ -127,6 +130,7 @@ DEPENDENCIES
   rubocop-graphql
   rubocop-i18n
   rubocop-minitest
+  rubocop-obsession
   rubocop-performance
   rubocop-rails
   rubocop-rails-omakase
@@ -140,4 +144,4 @@ DEPENDENCIES
   test-prof
 
 BUNDLED WITH
-   2.4.10
+   2.4.17

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
     rubocop-minitest (0.35.0)
       rubocop (>= 1.61, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    rubocop-obsession (0.1.5)
+    rubocop-obsession (0.1.9)
       activesupport
       rubocop (~> 1.41)
     rubocop-performance (1.21.1)


### PR DESCRIPTION
This is to add [rubocop-obsession](https://github.com/jeromedalbert/rubocop-obsession) support.

I tried testing it with a custom image, but wasn't able to get that working. Adding it to beta looks like the best approach.

cc @BrianHawley